### PR TITLE
Back-compatibly add new progress columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # targets 0.0.2.9000
 
+## New features
 
+* Store `type`, `parent`, and `branches` in progress data for `tar_watch()` (#273, @mattwarkentin).
+* Add a `fields` argument in `tar_progress()` and default to `"progress"` for back compatibility (#273, @mattwarkentin).
 
 # targets 0.0.2
 

--- a/R/class_progress.R
+++ b/R/class_progress.R
@@ -115,7 +115,13 @@ progress_class <- R6::R6Class(
     write_progress = function(target, progress) {
       db <- self$database
       name <- target_get_name(target)
-      row <- list(name = name, progress = progress)
+      row <- list(
+        name = name,
+        type = target_get_type(target),
+        parent = target_get_parent(target),
+        branches = length(omit_na(target_get_children(target))),
+        progress = progress
+      )
       db$write_row(row)
     },
     write_running = function(target) {
@@ -196,5 +202,5 @@ path_progress <- function() {
 }
 
 header_progress <- function() {
-  c("name", "progress")
+  c("name", "type", "parent", "branches", "progress")
 }

--- a/R/class_progress.R
+++ b/R/class_progress.R
@@ -115,11 +115,17 @@ progress_class <- R6::R6Class(
     write_progress = function(target, progress) {
       db <- self$database
       name <- target_get_name(target)
+      type <- target_get_type(target)
+      branches <- trn(
+        identical(type, "stem"),
+        0L,
+        length(omit_na(target_get_children(target)))
+      )
       row <- list(
         name = name,
-        type = target_get_type(target),
+        type = type,
         parent = target_get_parent(target),
-        branches = length(omit_na(target_get_children(target))),
+        branches = branches,
         progress = progress
       )
       db$write_row(row)

--- a/R/tar_meta.R
+++ b/R/tar_meta.R
@@ -1,6 +1,10 @@
 #' @title Read a project's metadata.
 #' @export
 #' @description Read the metadata of all recorded targets and global objects.
+#' @details A metadata row only updates when the target is built.
+#'   [tar_progress()] shows information on targets that are running.
+#'   That is why the number of branches may disagree between [tar_meta()]
+#'   and [tar_progress()] for actively running pipelines.
 #' @return A data frame with one row per target/object and the selected fields.
 #' @param names Optional, names of the targets. If supplied, `tar_meta()`
 #'   only returns metadata on these targets.

--- a/R/utils_data.R
+++ b/R/utils_data.R
@@ -21,6 +21,10 @@ replace_na <- function(x, y) {
   x
 }
 
+omit_na <- function(x) {
+  x[!is.na(x)]
+}
+
 dir_create <- function(x) {
   if (!file.exists(x)) {
     dir.create(x, showWarnings = FALSE, recursive = TRUE)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -290,6 +290,7 @@ txtq
 UD
 UI
 un
+unexecutable
 unexportable
 unhandled
 Univa

--- a/man/tar_meta.Rd
+++ b/man/tar_meta.Rd
@@ -53,6 +53,12 @@ A data frame with one row per target/object and the selected fields.
 \description{
 Read the metadata of all recorded targets and global objects.
 }
+\details{
+A metadata row only updates when the target is built.
+\code{\link[=tar_progress]{tar_progress()}} shows information on targets that are running.
+That is why the number of branches may disagree between \code{\link[=tar_meta]{tar_meta()}}
+and \code{\link[=tar_progress]{tar_progress()}} for actively running pipelines.
+}
 \examples{
 if (identical(Sys.getenv("TAR_LONG_EXAMPLES"), "true")) {
 tar_dir({ # Write all files to a temporary directory.

--- a/man/tar_progress.Rd
+++ b/man/tar_progress.Rd
@@ -4,18 +4,28 @@
 \alias{tar_progress}
 \title{Read the target progress of the latest run of the pipeline.}
 \usage{
-tar_progress(names = NULL)
+tar_progress(names = NULL, fields = "progress")
 }
 \arguments{
 \item{names}{Optional, names of the targets. If supplied, \code{tar_progress()}
 only returns progress information on these targets.
 You can supply symbols, a character vector,
 or \code{tidyselect} helpers like \code{\link[=starts_with]{starts_with()}}.}
+
+\item{fields}{Optional, names of progress data columns to read.
+Set to \code{NULL} to read all fields.}
 }
 \value{
 A data frame with one row per target and the following columns:
 \itemize{
-\item \code{name}: name of the target or global object.
+\item \code{name}: name of the target.
+\item \code{type}: type of target: \code{"stem"} for non-branching targets,
+\code{"pattern"} for dynamically branching targets, and \code{"branch"}
+for dynamic branches.
+\item \code{parent}: name of the target's parent. For branches, this is the
+name of the associated pattern. For other targets, the pattern
+is just itself.
+\item \code{branches}: number of dynamic branches of a pattern. 0 for non-patterns.
 \item \code{progress}: the most recent progress update of that target.
 Could be \code{"running"}, \code{"built"}, \code{"cancelled"}, or \code{"failed"}.
 }

--- a/tests/testthat/test-class_progress.R
+++ b/tests/testthat/test-class_progress.R
@@ -179,7 +179,7 @@ tar_test("progress records dynamic branching data", {
     )
   )
   tar_make(callr_function = NULL)
-  out <- tar_progress()
+  out <- tar_progress(fields = NULL)
   branches <- out[out$type == "branch", ]
   expect_equal(dim(branches), c(2L, 5L))
   expect_true(all(grepl("^y_", branches$name)))
@@ -205,7 +205,7 @@ tar_test("progress records dynamic branching error status", {
     )
   )
   expect_error(tar_make(callr_function = NULL))
-  out <- tar_progress()
+  out <- tar_progress(fields = NULL)
   x <- out[out$progress == "errored" & out$type == "pattern", ]
   expect_equal(x$name, "y")
   expect_equal(x$type, "pattern")

--- a/tests/testthat/test-class_progress.R
+++ b/tests/testthat/test-class_progress.R
@@ -75,7 +75,14 @@ tar_test("progress$register_running()", {
   progress$register_running(target_init("x", 1))
   expect_equal(counter_get_names(progress$running), "x")
   data <- progress$database$read_data()
-  expect_equal(data, data_frame(name = "x", progress = "running"))
+  exp <- data_frame(
+    name = "x",
+    type = "stem",
+    parent = "x",
+    branches = 0L,
+    progress = "running"
+  )
+  expect_equal(data, exp)
 })
 
 tar_test("progress$register_built()", {
@@ -84,7 +91,14 @@ tar_test("progress$register_built()", {
   progress$register_built(target_init("x", 1))
   expect_equal(counter_get_names(progress$built), "x")
   data <- progress$database$read_data()
-  expect_equal(data, data_frame(name = "x", progress = "built"))
+  exp <- data_frame(
+    name = "x",
+    type = "stem",
+    parent = "x",
+    branches = 0L,
+    progress = "built"
+  )
+  expect_equal(data, exp)
 })
 
 tar_test("progress$register_cancelled()", {
@@ -93,7 +107,14 @@ tar_test("progress$register_cancelled()", {
   progress$register_cancelled(target_init("x", 1))
   expect_equal(counter_get_names(progress$cancelled), "x")
   data <- progress$database$read_data()
-  expect_equal(data, data_frame(name = "x", progress = "cancelled"))
+  exp <- data_frame(
+    name = "x",
+    type = "stem",
+    parent = "x",
+    branches = 0L,
+    progress = "cancelled"
+  )
+  expect_equal(data, exp)
 })
 
 tar_test("progress$register_errored()", {
@@ -102,7 +123,14 @@ tar_test("progress$register_errored()", {
   progress$register_errored(target_init("x", 1))
   expect_equal(counter_get_names(progress$errored), "x")
   data <- progress$database$read_data()
-  expect_equal(data, data_frame(name = "x", progress = "errored"))
+  exp <- data_frame(
+    name = "x",
+    type = "stem",
+    parent = "x",
+    branches = 0L,
+    progress = "errored"
+  )
+  expect_equal(data, exp)
 })
 
 tar_test("progress$any_remaining() while queued", {
@@ -127,6 +155,9 @@ tar_test("progress database gets used", {
   out <- local$scheduler$progress$database$read_data()
   exp <- data_frame(
     name = c("x", "x", "y", "y"),
+    type = rep("stem", 4L),
+    parent = c("x", "x", "y", "y"),
+    branches = rep(0L, 4L),
     progress = c("running", "built", "running", "built")
   )
   expect_equal(out, exp)
@@ -135,7 +166,8 @@ tar_test("progress database gets used", {
   local <- local_init(pipeline_init(list(x, y)))
   local$run()
   out <- local$scheduler$progress$database$read_data()
-  expect_equal(colnames(out), c("name", "progress"))
+  exp <- c("name", "type", "parent", "branches", "progress")
+  expect_equal(colnames(out), exp)
   expect_equal(nrow(out), 0L)
 })
 

--- a/tests/testthat/test-class_url.R
+++ b/tests/testthat/test-class_url.R
@@ -20,7 +20,7 @@ tar_test("dynamic urls work", {
     branches = 0L,
     progress = "built"
   )
-  expect_equal(tar_progress(), exp)
+  expect_equal(tar_progress(fields = NULL), exp)
   tar_make(callr_function = NULL)
   expect_equal(nrow(tar_progress()), 0)
   meta <- tar_meta(abc)

--- a/tests/testthat/test-class_url.R
+++ b/tests/testthat/test-class_url.R
@@ -13,7 +13,13 @@ tar_test("dynamic urls work", {
     )
   })
   tar_make(callr_function = NULL)
-  exp <- tibble::tibble(name = "abc", progress = "built")
+  exp <- tibble::tibble(
+    name = "abc",
+    type = "stem",
+    parent = "abc",
+    branches = 0L,
+    progress = "built"
+  )
   expect_equal(tar_progress(), exp)
   tar_make(callr_function = NULL)
   expect_equal(nrow(tar_progress()), 0)

--- a/tests/testthat/test-tar_progress.R
+++ b/tests/testthat/test-tar_progress.R
@@ -1,14 +1,31 @@
-tar_test("tar_progress() works", {
+tar_test("tar_progress() with defaults", {
   pipeline <- pipeline_init(list(target_init("x", quote(1))))
   local_init(pipeline = pipeline)$run()
   out <- tar_progress()
-  expect_equal(dim(out), c(1L, 5L))
+  expect_equal(dim(out), c(1L, 2L))
   expect_equal(out$name, "x")
   expect_equal(out$progress, "built")
+})
+
+tar_test("tar_progress() with fields = NULL", {
+  pipeline <- pipeline_init(list(target_init("x", quote(1))))
+  local_init(pipeline = pipeline)$run()
+  out <- tar_progress(fields = NULL)
+  expect_equal(dim(out), c(1L, 5L))
+  expect_equal(out$name, "x")
   expect_equal(out$type, "stem")
   expect_equal(out$parent, "x")
   expect_equal(out$branches, 0L)
   expect_equal(out$progress, "built")
+})
+
+tar_test("tar_progress() tidyselect", {
+  pipeline <- pipeline_init(list(target_init("x", quote(1))))
+  local_init(pipeline = pipeline)$run()
+  out <- tar_progress(fields = type)
+  expect_equal(dim(out), c(1L, 2L))
+  expect_equal(out$name, "x")
+  expect_equal(out$type, "stem")
 })
 
 tar_test("tar_progress() with target selection", {

--- a/tests/testthat/test-tar_progress.R
+++ b/tests/testthat/test-tar_progress.R
@@ -2,8 +2,12 @@ tar_test("tar_progress() works", {
   pipeline <- pipeline_init(list(target_init("x", quote(1))))
   local_init(pipeline = pipeline)$run()
   out <- tar_progress()
-  expect_equal(dim(out), c(1L, 2L))
+  expect_equal(dim(out), c(1L, 5L))
   expect_equal(out$name, "x")
+  expect_equal(out$progress, "built")
+  expect_equal(out$type, "stem")
+  expect_equal(out$parent, "x")
+  expect_equal(out$branches, 0L)
   expect_equal(out$progress, "built")
 })
 


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an issue to the [issue tracker](http://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.
* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).

# Related GitHub issues and pull requests

* Ref: #273

# Summary

Adds columns `type`, `parent`, and `branches` to `_targets/meta/progress` to help with #273. `tar_progress()` output is back compatible (only 2 columns by default).

``` r
library(targets)
tar_script({
  options(crayon.enabled = FALSE)
  list(
    tar_target(x, seq_len(2)),
    tar_target(y, x, pattern = map(x))
  )
})

tar_make()
#> ● run target x
#> ● run branch y_29239c8a
#> ● run branch y_7cc32924
#> ● end pipeline

# new columns for tar_watch()
tar_progress(fields = NULL)
#> # A tibble: 4 x 5
#>   name       type    parent branches progress
#>   <chr>      <chr>   <chr>     <int> <chr>   
#> 1 x          stem    x             0 built   
#> 2 y_29239c8a branch  y             0 built   
#> 3 y_7cc32924 branch  y             0 built   
#> 4 y          pattern y             2 built

# back-compatible defaults
tar_progress()
#> # A tibble: 4 x 2
#>   name       progress
#>   <chr>      <chr>   
#> 1 x          built   
#> 2 y_29239c8a built   
#> 3 y_7cc32924 built   
#> 4 y          built
```

<sup>Created on 2021-01-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
