### PR TITLE
update lintr config for lintr >= 2

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,5 @@
 linters: with_defaults(
-  camel_case_linter = NULL,
   cyclocomp_linter = NULL,
   object_length_linter = NULL,
   object_name_linter = NULL,
-  object_usage_linter = NULL,
-  snake_case_linter = NULL)
+  object_usage_linter = NULL)


### PR DESCRIPTION
# Prework

* [+ ] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [+] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](http://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.
* [+] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).

# Related GitHub issues and pull requests

* Ref: # https://github.com/jimhester/lintr/blob/master/NEWS.md#lintr-200 - deprecation of `snake_case_linter` and `camel_case_linter`

- #295

# Summary

Please explain the purpose and scope of your contribution.

The package was set to use CRAN {lintr} (ie, >=v2)

`snake_case_linter` and `camel_case_linter` were originally NULL-ed out (deactivated) in the
{targets} .lintr config.

But, these linters were removed from lintr's default-linter set prior to
lintr v2 (so NULLing them in the config doesn't actually do anything).
In fact, the functions are being deprecated.

Hence I removed any mention of these linters from the targets .lintr.

Note that `snake_case_linter` / `camel_case_linter` are now implemented as
part of `object_name_linter()`, but that the latter was already deactivated in
the {targets} .lintr config.  