### PR TITLE
update README for dev server installation instructions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -31,7 +31,6 @@
 ^codemeta\.json$
 ^CONTRIBUTING.md$
 ^pkgdown$
-^README\.md$
 ^README\.Rmd$
 ^LICENSE\.md$
 ^paper\.md$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -31,6 +31,7 @@
 ^codemeta\.json$
 ^CONTRIBUTING.md$
 ^pkgdown$
+^README\.md$
 ^README\.Rmd$
 ^LICENSE\.md$
 ^paper\.md$

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,11 +41,16 @@ The `targets` package is a [Make](https://www.gnu.org/software/make/)-like pipel
 
 ## Installation
 
-You can install the GitHub development version of `targets` to access the latest features and patches.
+You can install `targets` from CRAN.
+```{r, eval = FALSE}
+install.packages("targets")
+```
+
+
+You can also install the development version of `targets` to access the latest features and patches using the ropensci development server.
 
 ```{r, eval = FALSE}
-library(remotes)
-install_github("ropensci/targets")
+install.packages("targets", repos = "https://dev.ropensci.org")
 ```
 
 ## Recorded talks

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,17 +41,11 @@ The `targets` package is a [Make](https://www.gnu.org/software/make/)-like pipel
 
 ## Installation
 
-You can install `targets` from CRAN.
-```{r, eval = FALSE}
-install.packages("targets")
-```
-
-
-You can also install the development version of `targets` to access the latest features and patches using the ropensci development server.
-
-```{r, eval = FALSE}
-install.packages("targets", repos = "https://dev.ropensci.org")
-```
+Type | Source | Command
+---|---|---
+Release | CRAN | `install.packages("targets")`
+Development | GitHub | `remotes::install_github("ropensci/targets")`
+Development | rOpenSci | `install.packages("targets", repos = "https://dev.ropensci.org")`
 
 ## Recorded talks
 

--- a/README.md
+++ b/README.md
@@ -64,18 +64,11 @@ the results.
 
 ## Installation
 
-You can install `targets` from CRAN.
-
-``` r
-install.packages("targets")
-```
-
-You can also install the development version of `targets` to access the
-latest features and patches using the ropensci development server.
-
-``` r
-install.packages("targets", repos = "https://dev.ropensci.org")
-```
+| Type        | Source   | Command                                                           |
+|-------------|----------|-------------------------------------------------------------------|
+| Release     | CRAN     | `install.packages("targets")`                                     |
+| Development | GitHub   | `remotes::install_github("ropensci/targets")`                     |
+| Development | rOpenSci | `install.packages("targets", repos = "https://dev.ropensci.org")` |
 
 ## Recorded talks
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ the results.
 ## How to get started
 
 1.  Watch minutes 6 through 40 of the [New York Open Statistical
-    Programming Meetup from
-    December 2020](https://youtu.be/Gqn7Xn4d5NI).
+    Programming Meetup from December
+    2020](https://youtu.be/Gqn7Xn4d5NI).
 2.  Read the [short walkthrough
     chapter](https://books.ropensci.org/targets/walkthrough.html) of the
     [user manual](https://books.ropensci.org/targets/).
@@ -64,59 +64,64 @@ the results.
 
 ## Installation
 
-You can install the GitHub development version of `targets` to access
-the latest features and patches.
+You can install `targets` from CRAN.
 
 ``` r
-library(remotes)
-install_github("ropensci/targets")
+install.packages("targets")
+```
+
+You can also install the development version of `targets` to access the
+latest features and patches using the ropensci development server.
+
+``` r
+install.packages("targets", repos = "https://dev.ropensci.org")
 ```
 
 ## Recorded talks
 
-  - [R/Pharma 2020
+-   [R/Pharma 2020
     (9:24)](https://www.youtube.com/watch?v=GRqKJBaC5g4&list=PLMtxz1fUYA5C0YflXsR8EEAQXfjntlV1H&index=6)
-  - [New York Open Statistical Programming Meetup, December 2020
+-   [New York Open Statistical Programming Meetup, December 2020
     (1:54:28)](https://youtu.be/Gqn7Xn4d5NI)
-  - [LA R Users Meetup, October 2020
+-   [LA R Users Meetup, October 2020
     (1:14:40)](https://www.youtube.com/watch?v=Qq25BUxpJu4)
 
 ## Documentation
 
-  - [User manual](https://books.ropensci.org/targets): in-depth
+-   [User manual](https://books.ropensci.org/targets): in-depth
     discussion about how to use `targets`.
-  - [Reference website](https://docs.ropensci.org/targets/): formal
+-   [Reference website](https://docs.ropensci.org/targets/): formal
     documentation of all user-side functions, the statement of need, and
     multiple design documents of the internal architecture.
-  - [Developer
+-   [Developer
     documentation](https://books.ropensci.org/targets-design): software
     design documents for developers contributing to the deep internal
     architecture of `targets`.
 
 ## Courses
 
-  - [Official half-day interactive
+-   [Official half-day interactive
     tutorial](https://github.com/wlandau/targets-tutorial).
 
 ## Example projects
 
-  - [Minimal example](https://github.com/wlandau/targets-minimal).
-  - [Machine learning with
+-   [Minimal example](https://github.com/wlandau/targets-minimal).
+-   [Machine learning with
     Keras](https://github.com/wlandau/targets-keras).
-  - [Validating a Stan model](https://github.com/wlandau/targets-stan).
+-   [Validating a Stan model](https://github.com/wlandau/targets-stan).
 
 ## Apps
 
-  - [`targets-shiny`](https://github.com/wlandau/targets-shiny): a
+-   [`targets-shiny`](https://github.com/wlandau/targets-shiny): a
     simple prototype of a Shiny app with a `targets` backend. Shows how
     to build powerful data pipelines inside apps.
-  - [`tar_watch()`](https://docs.ropensci.org/targets/reference/tar_watch.html):
+-   [`tar_watch()`](https://docs.ropensci.org/targets/reference/tar_watch.html):
     a built-in Shiny app to visualize progress while a pipeline is
     running. Available as a Shiny module via
     [`tar_watch_ui()`](https://docs.ropensci.org/targets/reference/tar_watch_ui.html)
     and
     [`tar_watch_server()`](https://docs.ropensci.org/targets/reference/tar_watch_server.html).
-  - [`targetsketch`](https://wlandau.shinyapps.io/targetsketch): a Shiny
+-   [`targetsketch`](https://wlandau.shinyapps.io/targetsketch): a Shiny
     app to help sketch pipelines
     ([app](https://wlandau.shinyapps.io/targetsketch),
     [source](https://github.com/wlandau/targetsketch)).
@@ -134,13 +139,13 @@ and [`tarchetypes`](https://docs.ropensci.org/tarchetypes).
 
 ## Help
 
-  - Post to the [GitHub issue
+-   Post to the [GitHub issue
     tracker](https://github.com/ropensci/targets/issues) to elicit help
     from the maintainer.
-  - The [RStudio Community](https://community.rstudio.com/) forum is
+-   The [RStudio Community](https://community.rstudio.com/) forum is
     full of friendly enthusiasts of R and the tidyverse. Use the
     [`targets` tag](https://community.rstudio.com/tag/targets).
-  - [Stack Overflow](https://stackoverflow.com/) broadcasts to the
+-   [Stack Overflow](https://stackoverflow.com/) broadcasts to the
     entire open source community. Use the [`targets-r-package`
     tag](https://stackoverflow.com/questions/tagged/targets-r-package).
 


### PR DESCRIPTION
# Prework

* [X] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](http://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.
* [X] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).

# Summary

Sorry for the unsolicited PR. Going to install the dev version of targets I noticed that the CRAN installation instructions weren't yet available in the README. In addition, I think it is worthwhile to leverage the ropensci dev server so I have modified those installation instructions.

One last note - the README is currently ignored in the R build so it isn't available on CRAN. Is that purposeful?
