### PR TITLE
Work around tar_poll() race condition on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 * Return correct error messages from feather and parquet formats (#388). Now calling `assert_df()` from `store_assert_format()` instead of `store_cast_object()`. And now those last two functions are not called at all if the target throws an error.
+* Retry writing lines to database files so Windows machines can run `tar_poll()` at the same time as the pipeline (#393).
 
 ## New features
 

--- a/R/class_database.R
+++ b/R/class_database.R
@@ -98,9 +98,19 @@ database_class <- R6::R6Class(
       as.list(data)[self$header]
     },
     write_row = function(row) {
-      row <- self$select_cols(row)
-      line <- self$produce_line(row)
+      line <- self$produce_line(self$select_cols(row))
+      self$append_line(line)
+    },
+    append_line = function(line) {
+      while(!is.null(try(self$try_append_line(line)))) {
+        msg <- paste("Reattempting to append line to", self$path)
+        cli::cli_alert_info(msg)
+        Sys.sleep(stats::runif(1, 0.1, 0.2))
+      }
+    },
+    try_append_line = function(line) {
       write(line, self$path, ncolumns = 1L, append = TRUE, sep = "")
+      invisible()
     },
     append_storage = function(data) {
       dir_create(dirname(self$path))

--- a/R/class_database.R
+++ b/R/class_database.R
@@ -105,7 +105,7 @@ database_class <- R6::R6Class(
       attempt <- 0L
       # Tested in tests/interactive/test-database.R
       # nocov start
-      while(!is.null(try(self$try_append_line(line)))) {
+      while (!is.null(try(self$try_append_line(line)))) {
         msg <- paste("Reattempting to append line to", self$path)
         cli::cli_alert_info(msg)
         Sys.sleep(stats::runif(1, 0.2, 0.25))

--- a/R/class_database.R
+++ b/R/class_database.R
@@ -101,11 +101,21 @@ database_class <- R6::R6Class(
       line <- self$produce_line(self$select_cols(row))
       self$append_line(line)
     },
-    append_line = function(line) {
+    append_line = function(line, max_attempts = 500) {
+      attempt <- 0L
       while(!is.null(try(self$try_append_line(line)))) {
         msg <- paste("Reattempting to append line to", self$path)
         cli::cli_alert_info(msg)
-        Sys.sleep(stats::runif(1, 0.1, 0.2))
+        Sys.sleep(stats::runif(1, 0.2, 0.25))
+        attempt <- attempt + 1L
+        if (attempt > max_attempts) {
+          throw_run(
+            "timed out after ",
+            max_attempts,
+            "trying to append to ",
+            self$path
+          )
+        }
       }
     },
     try_append_line = function(line) {

--- a/R/class_database.R
+++ b/R/class_database.R
@@ -114,7 +114,7 @@ database_class <- R6::R6Class(
           throw_run(
             "timed out after ",
             max_attempts,
-            "trying to append to ",
+            " attempts trying to append to ",
             self$path
           )
         }

--- a/R/tar_package.R
+++ b/R/tar_package.R
@@ -12,7 +12,7 @@
 #'   and `drake` by Will Landau (2018, \doi{doi:10.21105/joss.00550}).
 #' @name targets-package
 #' @importFrom callr r r_bg
-#' @importFrom cli col_green make_spinner symbol
+#' @importFrom cli cli_alert_info col_green make_spinner symbol
 #' @importFrom codetools findGlobals
 #' @importFrom data.table data.table fread fwrite set
 #' @importFrom digest digest digest2int

--- a/tests/interactive/test-database.R
+++ b/tests/interactive/test-database.R
@@ -21,7 +21,7 @@ tar_test("test on Windows: pipeline keeps going #393", {
   tar_poll()
   # Pipline should be up to date now.
   expect_equal(tar_outdated(), character(0))
-  # Should see error messages that it cannot append
+  # Should see error messages that it could not append
   # to progress but reattempted to do so.
   writeLines(readLines("err.txt"))
 })

--- a/tests/interactive/test-database.R
+++ b/tests/interactive/test-database.R
@@ -1,5 +1,27 @@
 tar_test("database$append_line() loops when it cannot append to the file", {
   path <- file.path(tempfile(), "x", "y")
   database <- database_init(path = path)
-  database$append_line("line")
+  database$append_line("line", max_attempts = 10)
+})
+
+tar_test("test on Windows: pipeline keeps going #393", {
+  tar_script(
+    list(
+      tar_target(n_random, rep(1, 200)),
+      tar_target(random, Sys.sleep(0.01), pattern = map(n_random))
+    )
+  )
+  px <- tar_make(
+    callr_function = callr::r_bg,
+    callr_arguments = list(
+      stdout = "out.txt",
+      stderr = "err.txt"
+    )
+  )
+  tar_poll()
+  # Pipline should be up to date now.
+  expect_equal(tar_outdated(), character(0))
+  # Should see error messages that it cannot append
+  # to progress but reattempted to do so.
+  writeLines(readLines("err.txt"))
 })


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](http://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.
* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).

# Related GitHub issues and pull requests

* Ref: #393

# Summary

In this PR, `targets` reattempts to write lines to database files when the original write fails. Seems to work when I tested it on Windows. `try()` + retries is not an ideal way to resolve a race condition, but it is the best I think I can do for now.
