### PR TITLE
Log skipped targets

### DIFF
--- a/R/class_active.R
+++ b/R/class_active.R
@@ -81,10 +81,11 @@ active_class <- R6::R6Class(
     },
     skip_target = function(target) {
       target_skip(
-        target,
-        self$pipeline,
-        self$scheduler,
-        self$meta
+        target = target,
+        pipeline = self$pipeline,
+        scheduler = self$scheduler,
+        meta = self$meta,
+        active = TRUE
       )
       target_sync_file_meta(target, self$meta)
     },

--- a/R/class_builder.R
+++ b/R/class_builder.R
@@ -104,7 +104,7 @@ target_skip.tar_builder <- function(target, pipeline, scheduler, meta) {
   path <- meta$get_record(target_get_name(target))$path
   file <- target$store$file
   file$path <- path
-  scheduler$progress$assign_skipped(target)
+  scheduler$progress$register_skipped(target)
   scheduler$reporter$report_skipped(target, scheduler$progress)
 }
 

--- a/R/class_builder.R
+++ b/R/class_builder.R
@@ -99,12 +99,22 @@ target_run_worker.tar_builder <- function(target, envir, path_store, options) {
 }
 
 #' @export
-target_skip.tar_builder <- function(target, pipeline, scheduler, meta) {
+target_skip.tar_builder <- function(
+  target,
+  pipeline,
+  scheduler,
+  meta,
+  active
+) {
   target_update_queue(target, scheduler)
   path <- meta$get_record(target_get_name(target))$path
   file <- target$store$file
   file$path <- path
-  scheduler$progress$register_skipped(target)
+  if_any(
+    active,
+    scheduler$progress$register_skipped(target),
+    scheduler$progress$assign_skipped(target)
+  )
   scheduler$reporter$report_skipped(target, scheduler$progress)
 }
 

--- a/R/class_clustermq.R
+++ b/R/class_clustermq.R
@@ -150,10 +150,11 @@ clustermq_class <- R6::R6Class(
     skip_target = function(target) {
       self$wait_or_shutdown()
       target_skip(
-        target,
-        self$pipeline,
-        self$scheduler,
-        self$meta
+        target = target,
+        pipeline = self$pipeline,
+        scheduler = self$scheduler,
+        meta = self$meta,
+        active = TRUE
       )
       target_sync_file_meta(target, self$meta)
     },

--- a/R/class_outdated.R
+++ b/R/class_outdated.R
@@ -96,7 +96,13 @@ outdated_class <- R6::R6Class(
     },
     process_builder_exists = function(target) {
       tryCatch(
-        target_skip(target, self$pipeline, self$scheduler, self$meta),
+        target_skip(
+          target = target,
+          pipeline = self$pipeline,
+          scheduler = self$scheduler,
+          meta = self$meta,
+          active = FALSE
+        ),
         error = function(e) warning(e$message)
       )
       target_update_depend(target, self$pipeline, self$meta)
@@ -124,7 +130,13 @@ outdated_class <- R6::R6Class(
         self$register_outdated(target_get_name(target))
         return()
       }
-      target_skip(target, self$pipeline, self$scheduler, self$meta)
+      target_skip(
+        target = target,
+        pipeline = self$pipeline,
+        scheduler = self$scheduler,
+        meta = self$meta,
+        active = FALSE
+      )
       if (any(map_lgl(target_get_children(target), self$is_outdated))) {
         self$register_outdated(target_get_name(target))
       }

--- a/R/class_pattern.R
+++ b/R/class_pattern.R
@@ -234,6 +234,8 @@ pattern_conclude_final <- function(target, pipeline, scheduler, meta) {
   patternview_register_final(target$patternview, target, scheduler)
   if (identical(target$patternview$progress, "built")) {
     scheduler$reporter$report_built(target, scheduler$progress)
+  } else if (identical(target$patternview$progress, "skipped")) {
+    scheduler$reporter$report_skipped(target, scheduler$progress)
   }
 }
 

--- a/R/class_pattern.R
+++ b/R/class_pattern.R
@@ -37,7 +37,13 @@ target_produce_record.tar_pattern <- function(target, pipeline, meta) {
 }
 
 #' @export
-target_skip.tar_pattern <- function(target, pipeline, scheduler, meta) {
+target_skip.tar_pattern <- function(
+  target,
+  pipeline,
+  scheduler,
+  meta,
+  active
+) {
   if_any(
     is.null(target$junction),
     pattern_skip_initial(target, pipeline, scheduler, meta),

--- a/R/class_patternview.R
+++ b/R/class_patternview.R
@@ -48,6 +48,9 @@ patternview_register_final <- function(patternview, target, scheduler) {
   if (identical(patternview$progress, "started")) {
     patternview$progress <- "built"
     scheduler$progress$write_built(target)
+  } else if (identical(patternview$progress, "queued")) {
+    patternview$progress <- "skipped"
+    scheduler$progress$write_skipped(target)
   }
 }
 

--- a/R/class_progress.R
+++ b/R/class_progress.R
@@ -131,6 +131,9 @@ progress_class <- R6::R6Class(
       )
       db$write_row(row)
     },
+    write_skipped = function(target) {
+      self$write_progress(target, progress = "skipped")
+    },
     write_started = function(target) {
       self$write_progress(target, progress = "started")
     },
@@ -142,6 +145,10 @@ progress_class <- R6::R6Class(
     },
     write_canceled = function(target) {
       self$write_progress(target, progress = "canceled")
+    },
+    register_skipped = function(target) {
+      self$assign_skipped(target)
+      self$write_skipped(target)
     },
     register_started = function(target) {
       self$assign_started(target)

--- a/R/class_sitrep.R
+++ b/R/class_sitrep.R
@@ -61,7 +61,13 @@ sitrep_class <- R6::R6Class(
     },
     process_pattern = function(target) {
       if (all(map_lgl(target$settings$dimensions, self$has_children))) {
-        target_skip(target, self$pipeline, self$scheduler, self$meta)
+        target_skip(
+          target = target,
+          pipeline = self$pipeline,
+          scheduler = self$scheduler,
+          meta = self$meta,
+          active = FALSE
+        )
       }
     },
     process_builder = function(target) {
@@ -71,7 +77,13 @@ sitrep_class <- R6::R6Class(
       self$sitrep[[name]] <- builder_sitrep(target, self$meta)
       if_any(
         self$meta$exists_record(target_get_name(target)),
-        target_skip(target, self$pipeline, self$scheduler, self$meta),
+        target_skip(
+          target = target,
+          pipeline = self$pipeline,
+          scheduler = self$scheduler,
+          meta = self$meta,
+          active = FALSE
+        ),
         target_update_queue(target, self$scheduler)
       )
     },

--- a/R/class_stem.R
+++ b/R/class_stem.R
@@ -71,7 +71,7 @@ target_produce_record.tar_stem <- function(target, pipeline, meta) {
 }
 
 #' @export
-target_skip.tar_stem <- function(target, pipeline, scheduler, meta) {
+target_skip.tar_stem <- function(target, pipeline, scheduler, meta, active) {
   NextMethod()
   stem_restore_buds(target, pipeline, scheduler, meta)
 }

--- a/R/class_target.R
+++ b/R/class_target.R
@@ -193,7 +193,7 @@ target_produce_record <- function(target, pipeline, meta) {
   UseMethod("target_produce_record")
 }
 
-target_skip <- function(target, pipeline, scheduler, meta) {
+target_skip <- function(target, pipeline, scheduler, meta, active) {
   UseMethod("target_skip")
 }
 

--- a/R/class_visnetwork.R
+++ b/R/class_visnetwork.R
@@ -96,7 +96,8 @@ visnetwork_class <- R6::R6Class(
         started = "#DC863B",
         canceled = "#FAD510",
         errored = "#C93312",
-        dormant = "#D2D2D0",
+        queued = "#D2D2D0",
+        skipped = "#3e236e",
         none = "#94a4ac"
       )
       colors[status]

--- a/R/tar_poll.R
+++ b/R/tar_poll.R
@@ -25,7 +25,7 @@
 tar_poll <- function(
   interval = 1,
   timeout = Inf,
-  fields = c("started", "built", "errored", "canceled", "since"),
+  fields = c("skipped", "started", "built", "errored", "canceled", "since"),
   store = targets::tar_config_get("store")
 ) {
   start <- proc.time()["elapsed"]

--- a/R/tar_progress_branches.R
+++ b/R/tar_progress_branches.R
@@ -63,7 +63,7 @@ tar_progress_branches_summary <- function(progress) {
     progress = gsub(".* ", "", group),
     branches = as.integer(table)
   )
-  levels <- c("started", "built", "errored", "canceled")
+  levels <- c("skipped", "started", "built", "errored", "canceled")
   bins <- map(levels, ~tar_progress_branches_bin(.x, long))
   out <- progress[progress$type == "pattern",, drop = FALSE] # nolint
   out <- tibble::tibble(name = out$name, branches = out$branches)

--- a/R/tar_progress_summary.R
+++ b/R/tar_progress_summary.R
@@ -30,7 +30,7 @@
 #' })
 #' }
 tar_progress_summary <- function(
-  fields = c("started", "built", "errored", "canceled", "since"),
+  fields = c("skipped", "started", "built", "errored", "canceled", "since"),
   store = targets::tar_config_get("store")
 ) {
   assert_path(path_progress(path_store = store))
@@ -39,6 +39,7 @@ tar_progress_summary <- function(
   progress <- tibble::as_tibble(progress$database$read_condensed_data())
   progress <- progress[progress$type != "pattern",, drop = FALSE] # nolint
   out <- tibble::tibble(
+    skipped = sum(progress$progress == "skipped"),
     started = sum(progress$progress == "started"),
     built = sum(progress$progress == "built"),
     errored = sum(progress$progress == "errored"),
@@ -65,9 +66,9 @@ tar_progress_display_gt <- function(progress) {
     locations = gt::cells_column_labels(everything())
   )
   colors <- data_frame(
-    progress = c("started", "built", "canceled", "errored"),
-    fill = c("#DC863B", "#E1BD6D", "#FAD510", "#C93312"),
-    color = c("black", "black", "black", "white")
+    progress = c("skipped", "started", "built", "canceled", "errored"),
+    fill = c("#3e236e", "#DC863B", "#E1BD6D", "#FAD510", "#C93312"),
+    color = c("white", "black", "black", "black", "white")
   )
   for (index in seq_len(nrow(colors))) {
     out <- gt::tab_style(

--- a/man/tar_poll.Rd
+++ b/man/tar_poll.Rd
@@ -7,7 +7,7 @@
 tar_poll(
   interval = 1,
   timeout = Inf,
-  fields = c("started", "built", "errored", "canceled", "since"),
+  fields = c("skipped", "started", "built", "errored", "canceled", "since"),
   store = targets::tar_config_get("store")
 )
 }

--- a/man/tar_progress_summary.Rd
+++ b/man/tar_progress_summary.Rd
@@ -5,7 +5,7 @@
 \title{Summarize target progress.}
 \usage{
 tar_progress_summary(
-  fields = c("started", "built", "errored", "canceled", "since"),
+  fields = c("skipped", "started", "built", "errored", "canceled", "since"),
   store = targets::tar_config_get("store")
 )
 }

--- a/tests/interactive/test-tar_watch.R
+++ b/tests/interactive/test-tar_watch.R
@@ -25,6 +25,8 @@ tar_watch(
 )
 # The main process should be free to run the pipeline.
 tar_make()
+# Run it again and see skipped targets.
+tar_make()
 # Restarting the session should terminate the app.
 rstudioapi::restartSession()
 tar_destroy()
@@ -67,6 +69,8 @@ tar_watch(
   height = "450px"
 )
 # The main process should be free to run the pipeline.
+tar_make()
+# Run it again to see skipped branches.
 tar_make()
 # Look at the canceled branches in the "branches" view.
 tar_script({

--- a/tests/interactive/test-visnetwork.R
+++ b/tests/interactive/test-visnetwork.R
@@ -13,9 +13,28 @@ vis$update()
 # of upstream degree 2 and downstream degree 0.
 vis$visnetwork
 
+# Same but with everything queued.
+net <- inspection_init(pipeline_cross(), outdated = FALSE)
+vis <- visnetwork_init(network = net, degree_from = 2, degree_to = 0)
+vis$update()
+vis$visnetwork
+
 # Should show an inspection with everything up to date
-local_init(pipeline = pipeline_cross(), reporter = "silent")$run()
+local_init(pipeline = pipeline_cross(), reporter = "summary")$run()
 net <- inspection_init(pipeline_cross())
+vis <- visnetwork_init(network = net)
+vis$update()
+vis$visnetwork
+
+# Same with everything built.
+net <- inspection_init(pipeline_cross(), outdated = FALSE)
+vis <- visnetwork_init(network = net)
+vis$update()
+vis$visnetwork
+
+# Same with everything skipped.
+local_init(pipeline = pipeline_cross(), reporter = "summary")$run()
+net <- inspection_init(pipeline_cross(), outdated = FALSE)
 vis <- visnetwork_init(network = net)
 vis$update()
 vis$visnetwork

--- a/tests/interactive/test-visnetwork.R
+++ b/tests/interactive/test-visnetwork.R
@@ -233,13 +233,13 @@ tar_visnetwork(targets_only = FALSE)
 # Should show a graph of 3 targets, f(), g(), and miscellaneous globals.
 tar_visnetwork(targets_only = FALSE, callr_function = NULL)
 
-# Should show a status of targets as dormant (light gray).
+# Should show a status of targets as queued (light gray).
 tar_visnetwork(targets_only = FALSE, outdated = FALSE)
 
 # Should show a graph of just y1 and y2.
 tar_visnetwork(allow = starts_with("y"))
 
-# Should show status dormant (light gray).
+# Should show status queued (light gray).
 tar_visnetwork(outdated = FALSE)
 
 # Should show a canceled target.
@@ -248,7 +248,6 @@ tar_make()
 tar_visnetwork(outdated = FALSE)
 
 # Neighborhoods
-# Should show a glimpse of three targets.
 tar_script({
   g <- function(x) x - 1
   f <- function(x) g(x) + 1

--- a/tests/testthat/test-class_imports.R
+++ b/tests/testthat/test-class_imports.R
@@ -104,7 +104,7 @@ tar_test("imports setting works", {
   expect_equal(tar_read(x), 2L)
   # Should be up to date.
   tar_make(callr_function = NULL)
-  expect_equal(nrow(tar_progress()), 0L)
+  expect_equal(tar_progress(x)$progress, "skipped")
   out <- tar_outdated(callr_function = NULL, targets_only = FALSE)
   expect_equal(out, character(0))
   # Change the inner function.
@@ -115,6 +115,6 @@ tar_test("imports setting works", {
   out <- tar_outdated(callr_function = NULL, targets_only = FALSE)
   expect_true(all(c("f", "g", "x") %in% out))
   tar_make(callr_function = NULL)
-  expect_equal(tar_progress()$name, "x")
+  expect_equal(tar_progress(x)$progress, "built")
   expect_equal(tar_read(x), 3L)
 })

--- a/tests/testthat/test-class_progress.R
+++ b/tests/testthat/test-class_progress.R
@@ -168,7 +168,8 @@ tar_test("progress database gets used", {
   out <- local$scheduler$progress$database$read_data()
   exp <- c("name", "type", "parent", "branches", "progress")
   expect_equal(colnames(out), exp)
-  expect_equal(nrow(out), 0L)
+  expect_equal(nrow(out), 2L)
+  expect_equal(out$progress, rep("skipped", 2L))
 })
 
 tar_test("progress records dynamic branching data", {

--- a/tests/testthat/test-class_store.R
+++ b/tests/testthat/test-class_store.R
@@ -76,7 +76,7 @@ tar_test("alternate storage with _targets.yaml", {
   # Should be no invalidated targets
   expect_equal(tar_outdated(callr_function = NULL), character(0))
   tar_make(callr_function = NULL, envir = tar_option_get("envir"))
-  expect_equal(nrow(tar_progress()), 0L)
+  expect_equal(unique(tar_progress()$progress), "skipped")
   # Moving data store should not invalidate targets.
   file.rename(path, path_store_default())
   unlink("_targets.yaml")
@@ -84,5 +84,5 @@ tar_test("alternate storage with _targets.yaml", {
   expect_true(file.exists(path_store_default()))
   expect_equal(tar_outdated(callr_function = NULL), character(0))
   tar_make(callr_function = NULL, envir = tar_option_get("envir"))
-  expect_equal(nrow(tar_progress()), 0L)
+  expect_equal(unique(tar_progress()$progress), "skipped")
 })

--- a/tests/testthat/test-class_target.R
+++ b/tests/testthat/test-class_target.R
@@ -365,7 +365,7 @@ tar_test("invalidation: change a nested function", {
   expect_equal(tar_read(x), 2L)
   # Should be up to date.
   tar_make(callr_function = NULL)
-  expect_equal(nrow(tar_progress()), 0L)
+  expect_equal(tar_progress()$progress, "skipped")
   out <- tar_outdated(callr_function = NULL, targets_only = FALSE)
   expect_equal(out, character(0))
   # Change the inner function.
@@ -385,6 +385,6 @@ tar_test("invalidation: change a nested function", {
   out <- tar_outdated(callr_function = NULL, targets_only = FALSE)
   expect_true(all(c("f", "g", "x") %in% out))
   tar_make(callr_function = NULL)
-  expect_equal(tar_progress()$name, "x")
+  expect_equal(tar_progress()$progress, "built")
   expect_equal(tar_read(x), 3L)
 })

--- a/tests/testthat/test-class_url.R
+++ b/tests/testthat/test-class_url.R
@@ -23,7 +23,7 @@ tar_test("dynamic urls work", {
   )
   expect_equal(tar_progress(fields = NULL), exp)
   tar_make(callr_function = NULL)
-  expect_equal(nrow(tar_progress()), 0)
+  expect_equal(tar_progress()$progress, "skipped")
   meta <- tar_meta(abc)
   expect_equal(nchar(meta$data), 16)
   out <- meta$path[[1]]
@@ -62,7 +62,7 @@ tar_test("dynamic urls work from a custom data store", {
   )
   expect_equal(tar_progress(fields = NULL), exp)
   tar_make(callr_function = NULL)
-  expect_equal(nrow(tar_progress()), 0)
+  expect_equal(tar_progress()$progress, "skipped")
   meta <- tar_meta(abc)
   expect_equal(nchar(meta$data), 16)
   out <- meta$path[[1]]
@@ -80,7 +80,7 @@ tar_test("dynamic urls work from a custom data store", {
   expect_true(file.exists(path_store_default()))
   expect_equal(tar_outdated(callr_function = NULL), character(0))
   tar_make(callr_function = NULL)
-  expect_equal(nrow(tar_progress()), 0)
+  expect_equal(unique(tar_progress()$progress), "skipped")
 })
 
 tar_test("tar_condition_run error on bad URL", {

--- a/tests/testthat/test-tar_config_set.R
+++ b/tests/testthat/test-tar_config_set.R
@@ -118,7 +118,7 @@ tar_test("_targets.yaml is locked during the pipeline then unlocked after", {
   expect_equal(tar_config_get("store"), "_targets")
   expect_equal(tar_outdated(callr_function = NULL), character(0))
   tar_make(callr_function = NULL)
-  expect_equal(nrow(tar_progress()), 0L)
+  expect_equal(unique(tar_progress()$progress), "skipped")
 })
 
 tar_test("same with external process", {
@@ -137,7 +137,7 @@ tar_test("same with external process", {
   expect_equal(tar_config_get("store"), "_targets")
   expect_equal(tar_outdated(callr_function = NULL), character(0))
   tar_make(callr_function = NULL)
-  expect_equal(nrow(tar_progress()), 0L)
+  expect_equal(unique(tar_progress()$progress), "skipped")
 })
 
 tar_test("tar_config_set() can configure the script and the store", {

--- a/tests/testthat/test-tar_outdated.R
+++ b/tests/testthat/test-tar_outdated.R
@@ -8,6 +8,20 @@ tar_test("tar_outdated() does not create a data store", {
   expect_false(file.exists("_targets"))
 })
 
+tar_test("tar_outdated() does not modify progress", {
+  tar_script(
+    list(
+      tar_target(x, 1:2),
+      tar_target(y, x, pattern = map(x))
+    )
+  )
+  tar_make(callr_function = NULL)
+  out1 <- tar_progress()
+  tar_outdated(callr_function = NULL)
+  out2 <- tar_progress()
+  expect_equal(out1, out2)
+})
+
 tar_test("tar_outdated() without globals", {
   old <- Sys.getenv("TAR_WARN")
   Sys.setenv(TAR_WARN = "false")

--- a/tests/testthat/test-tar_progress.R
+++ b/tests/testthat/test-tar_progress.R
@@ -1,10 +1,12 @@
 tar_test("tar_progress() with defaults", {
-  pipeline <- pipeline_init(list(target_init("x", quote(1))))
-  local_init(pipeline = pipeline)$run()
-  out <- tar_progress()
-  expect_equal(dim(out), c(1L, 2L))
-  expect_equal(out$name, "x")
-  expect_equal(out$progress, "built")
+  for (result in c("built", "skipped")) {
+    pipeline <- pipeline_init(list(target_init("x", quote(1))))
+    local_init(pipeline = pipeline)$run()
+    out <- tar_progress()
+    expect_equal(dim(out), c(1L, 2L))
+    expect_equal(out$name, "x")
+    expect_equal(out$progress, result)
+  }
 })
 
 tar_test("tar_progress() with fields = NULL", {

--- a/tests/testthat/test-tar_progress_branches.R
+++ b/tests/testthat/test-tar_progress_branches.R
@@ -17,7 +17,15 @@ tar_test("tar_progress_branches()", {
   expect_error(tar_make(callr_function = NULL))
   out <- tar_progress_branches()
   expect_equal(nrow(out), 2)
-  cols <- c("name", "branches", "skipped", "started", "built", "errored", "canceled")
+  cols <- c(
+    "name",
+    "branches",
+    "skipped",
+    "started",
+    "built",
+    "errored",
+    "canceled"
+  )
   expect_equal(colnames(out), cols)
   out <- tar_progress_branches(names = y)
   expect_equal(nrow(out), 1)

--- a/tests/testthat/test-tar_progress_branches.R
+++ b/tests/testthat/test-tar_progress_branches.R
@@ -3,7 +3,7 @@ tar_test("tar_progress_branches() on empty progress", {
   tar_make(callr_function = NULL)
   tar_make(callr_function = NULL)
   out <- tar_progress_branches()
-  expect_equal(dim(out), c(0L, 6L))
+  expect_equal(dim(out), c(0L, 7L))
 })
 
 tar_test("tar_progress_branches()", {
@@ -17,7 +17,7 @@ tar_test("tar_progress_branches()", {
   expect_error(tar_make(callr_function = NULL))
   out <- tar_progress_branches()
   expect_equal(nrow(out), 2)
-  cols <- c("name", "branches", "started", "built", "errored", "canceled")
+  cols <- c("name", "branches", "skipped", "started", "built", "errored", "canceled")
   expect_equal(colnames(out), cols)
   out <- tar_progress_branches(names = y)
   expect_equal(nrow(out), 1)

--- a/tests/testthat/test-tar_progress_summary.R
+++ b/tests/testthat/test-tar_progress_summary.R
@@ -17,7 +17,7 @@ tar_test("default progress", {
   out <- tar_progress_summary()
   expect_equal(
     colnames(out),
-    c("started", "built", "errored", "canceled", "since")
+    c("skipped", "started", "built", "errored", "canceled", "since")
   )
   expect_equal(out$started, 0L)
   expect_equal(out$built, 4L)

--- a/tests/testthat/test-tar_sitrep.R
+++ b/tests/testthat/test-tar_sitrep.R
@@ -23,6 +23,21 @@ tar_test("tar_sitrep() on an empty project", {
   expect_equiv(out, exp)
 })
 
+tar_test("tar_sitrep() does not modify progress", {
+  tar_script(
+    list(
+      tar_target(x, 1:2),
+      tar_target(y, x, pattern = map(x))
+    )
+  )
+  tar_make(callr_function = NULL)
+  out1 <- tar_progress()
+  tar_sitrep(callr_function = NULL)
+  out2 <- tar_progress()
+  expect_equal(out1, out2)
+})
+
+
 tar_test("tar_sitrep() on an empty project with callr process", {
   tar_script(
     list(


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #514

# Summary

This PR logs skipped targets and shows them in tar_progress(), tar_poll(), tar_watch(), tar_progress_branches(), and tar_progress_summary(). Should be easier to keep track of what the pipeline is doing. Worth the 6% speed cost for large up-to-date pipelines.

This required modification to the internal `target_skip()` method, which is called from both active algorithms like `tar_make()` and passive algorithms like `tar_outdated()`. We want to record skips in the former but not the latter.  
