### PR TITLE
Fixes issue with setting error as "abridge" via tar_option_set

### DIFF
--- a/R/class_settings.R
+++ b/R/class_settings.R
@@ -138,7 +138,7 @@ settings_validate <- function(settings) {
     settings$dimensions
   )
   tar_assert_chr(settings$iteration)
-  tar_assert_in(settings$error, c("stop", "continue", "workspace"))
+  tar_assert_in(settings$error, c("stop", "continue", "abridge", "workspace"))
   tar_assert_in(settings$memory, c("persistent", "transient"))
   tar_assert_lgl(settings$garbage_collection)
   tar_assert_scalar(settings$garbage_collection)


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Summary

Setting `error = "abridge"` via `tar_option_set()` would throw an error for the targets pipeline. This minor fix addresses that issue by adding `"abridge"` to the vector of allowable `error` settings.
