### PR TITLE
add rstudio addin: convert assignemt to tar_target

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,7 +88,9 @@ Suggests:
   testthat (>= 3.0.0),
   torch (>= 0.1.0),
   usethis (>= 1.6.3),
-  visNetwork (>= 2.0.9)
+  visNetwork (>= 2.0.9),
+  glue (>= 1.4.2),
+  stringr (>= 1.4.0)
 Encoding: UTF-8
 Language: en-US
 VignetteBuilder: knitr

--- a/R/rstudio_addin_tar_assignment_to_target.R
+++ b/R/rstudio_addin_tar_assignment_to_target.R
@@ -1,0 +1,26 @@
+# RStudio addins are tested interactively in
+# tests/interactive/test-rstudio_addins.R. # nolint
+# nocov start
+#' @title RStudio addin to replace an assignment with the corresponding `"tar_target()"` at current selection.
+#' @description For internal use only. Not a user-side function.
+#' @export
+#' @keywords internal
+#' @param context RStudio API context from
+#'   `rstudioapi::getActiveDocumentContext()`.
+rstudio_addin_tar_assignment_to_target <- function() {
+  tar_assert_package("rstudioapi")
+  tar_assert_package("glue")
+  tar_assert_package("stringr")
+  sel <- rstudioapi::selectionGet()$value
+  var_name <- stringr::str_extract(sel, "\\S+(?= ?<-)")
+  body <- stringr::str_remove(sel, "\\S+ ?<- ?")
+  body <- stringr::str_trim(body)
+  body <- strsplit(body, "\n")[[1]]
+  text <- glue::glue("tar_target(\n",
+                     "  {var_name},\n",
+                     "  {paste(body, collapse='\n  ')}\n",
+                     ")", trim = FALSE)
+  rstudioapi::insertText(text = text)
+}
+
+# nocov end

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -52,3 +52,8 @@ Name: Write target at cursor
 Description: Write tar_target() at the cursor position.
 Binding: rstudio_addin_tar_target
 Interactive: false
+
+Name: Convert assignment to target
+Description: Replace a selected assignment with a tar_target
+Binding: rstudio_addin_tar_assignment_to_target
+Interactive: false


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Summary

Hi there :)
Since the advent of target markdown I use targets a lot in a very interactive manner. Being able to quickly change a code chunk between R and targets is very handy and facilitates this. I wrote a little RStudio Addin that can automatically convert a regular R assignment with a possibly multi-line expression (with pipes) into a `tar_target` that might also be helpful for others.

e.g.:

```
angry_mpg <- mpg %>% 
    mutate(
      manufacturer = toupper(manufacturer)
    )
```

gets converted to:

```
tar_target(
  angry_mpg,
  mpg %>% 
      mutate(
        manufacturer = toupper(manufacturer)
      )
)
```

