### PR TITLE
remove requirement that tar_dir is imported with tar_test (fix #642)

### DIFF
--- a/R/tar_test.R
+++ b/R/tar_test.R
@@ -26,7 +26,7 @@ tar_test <- function(label, code) {
     tar_assert_package("testthat")
     code <- substitute(code)
     expr <- substitute(
-      tar_dir(testthat::test_that(label, code)),
+      targets::tar_dir(testthat::test_that(label, code)),
       env = list(label = label, code = code)
     )
     withr::local_envvar(c(TAR_ASK = "false", TAR_TEST = "true"))


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #642

# Summary

Remove the requirement that `tar_dir` is imported for `tar_test`.
