### PR TITLE
AWS S3 bucket-specific regions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # targets 0.8.1.9000
 
+## New features
+
+* Add a `region` argument to `tar_resources_aws()` to allow the user to explicitly declare a region for each AWS S3 buckets (@caewok, #681). Different buckets can have different regions. This feature required modifying the metadata path for AWS storage formats. Before, the first element of the path was simply the bucket name. Now, it is internally formatted like `"bucket=BUCKET:region=REGION"`, where `BUCKET` is the user-supplied bucket name and `REGION` is the user-supplied region name. The new `targets` is back-compatible with the old metadata format, but if you run the pipeline with `targets` >= 0.8.1.9000 and then downgrade to `targets` <= 0.8.1, any AWS targets will break.
+
 ## Enhancements
 
 * Document target name requirements in `tar_target()` and `tar_target_raw()` (@tjmahr, #679).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* Add a `region` argument to `tar_resources_aws()` to allow the user to explicitly declare a region for each AWS S3 buckets (@caewok, #681). Different buckets can have different regions. This feature required modifying the metadata path for AWS storage formats. Before, the first element of the path was simply the bucket name. Now, it is internally formatted like `"bucket=BUCKET:region=REGION"`, where `BUCKET` is the user-supplied bucket name and `REGION` is the user-supplied region name. The new `targets` is back-compatible with the old metadata format, but if you run the pipeline with `targets` >= 0.8.1.9000 and then downgrade to `targets` <= 0.8.1, any AWS targets will break.
+* Add a `region` argument to `tar_resources_aws()` to allow the user to explicitly declare a region for each AWS S3 buckets (@caewok, #681). Different buckets can now have different regions. This feature required modifying the metadata path for AWS storage formats. Before, the first element of the path was simply the bucket name. Now, it is internally formatted like `"bucket=BUCKET:region=REGION"`, where `BUCKET` is the user-supplied bucket name and `REGION` is the user-supplied region name. The new `targets` is back-compatible with the old metadata format, but if you run the pipeline with `targets` >= 0.8.1.9000 and then downgrade to `targets` <= 0.8.1, any AWS targets will break.
 
 ## Enhancements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Enhancements
 
 * Document target name requirements in `tar_target()` and `tar_target_raw()` (@tjmahr, #679).
+* Catch and relay any the error if a target cannot be checked in `target_should_run.tar_builder()`. These kinds of errors sometimes come up with AWS storage.
 
 # targets 0.8.1
 

--- a/R/class_aws.R
+++ b/R/class_aws.R
@@ -18,7 +18,6 @@ store_produce_aws_path <- function(store, name, object, path_store) {
   tar_assert_nonempty(region %|||% "region")
   tar_assert_chr(region %|||% "region")
   tar_assert_scalar(region %|||% "region")
-  tar_assert_nzchar(region %|||% "region")
   prefix <- store$resources$aws$prefix %|||%
     store$resources$prefix %|||%
     path_objects_dir_cloud()

--- a/R/class_aws_file.R
+++ b/R/class_aws_file.R
@@ -64,6 +64,7 @@ store_hash_early.tar_aws_file <- function(store, target) { # nolint
 store_read_object.tar_aws_file <- function(store) {
   path <- store$file$path
   bucket <- store_aws_bucket(path)
+  region <- store_aws_region(path)
   key <- store_aws_key(path)
   out <- store_aws_file_stage(path, key)
   dir_create(dirname(out))
@@ -71,6 +72,7 @@ store_read_object.tar_aws_file <- function(store) {
     object = key,
     bucket = bucket,
     file = out,
+    region = region,
     check_region = TRUE
   )
   out

--- a/R/class_resources_aws.R
+++ b/R/class_resources_aws.R
@@ -1,7 +1,7 @@
 resources_aws_init <- function(
   bucket = NULL,
   prefix = path_objects_dir_cloud(),
-  region = character(0)
+  region = NULL
 ) {
   resources_aws_new(
     bucket = bucket,

--- a/R/class_resources_aws.R
+++ b/R/class_resources_aws.R
@@ -31,7 +31,6 @@ resources_validate.tar_resources_aws <- function(resources) {
   tar_assert_nzchar(resources$prefix)
   tar_assert_scalar(resources$region %|||% "region")
   tar_assert_chr(resources$region %|||% "region")
-  tar_assert_nzchar(resources$region %|||% "region")
 }
 
 #' @export

--- a/R/class_resources_aws.R
+++ b/R/class_resources_aws.R
@@ -1,19 +1,23 @@
 resources_aws_init <- function(
   bucket = NULL,
-  prefix = path_objects_dir_cloud()
+  prefix = path_objects_dir_cloud(),
+  region = character(0)
 ) {
   resources_aws_new(
     bucket = bucket,
-    prefix = prefix
+    prefix = prefix,
+    region = region
   )
 }
 
 resources_aws_new <- function(
   bucket = NULL,
-  prefix = NULL
+  prefix = NULL,
+  region = NULL
 ) {
   force(bucket)
   force(prefix)
+  force(region)
   enclass(environment(), c("tar_resources_aws", "tar_resources"))
 }
 
@@ -25,6 +29,9 @@ resources_validate.tar_resources_aws <- function(resources) {
   tar_assert_scalar(resources$prefix)
   tar_assert_chr(resources$prefix)
   tar_assert_nzchar(resources$prefix)
+  tar_assert_scalar(resources$region %|||% "region")
+  tar_assert_chr(resources$region %|||% "region")
+  tar_assert_nzchar(resources$region %|||% "region")
 }
 
 #' @export

--- a/R/tar_resources_aws.R
+++ b/R/tar_resources_aws.R
@@ -28,7 +28,7 @@
 tar_resources_aws <- function(
   bucket,
   prefix = targets::path_objects_dir_cloud(),
-  region = character(0)
+  region = NULL
 ) {
   out <- resources_aws_init(
     bucket = bucket,

--- a/R/tar_resources_aws.R
+++ b/R/tar_resources_aws.R
@@ -12,6 +12,8 @@
 #'   of the affected targets during the pipeline.
 #' @param prefix Character of length 1, "directory path"
 #'   in the S3 bucket where the target return values are stored.
+#' @param region Character of length 1, AWS region containing the S3 bucket.
+#'   Set to `NULL` to use the default region.
 #' @examples
 #' # Somewhere in you target script file (usually _targets.R):
 #' tar_target(
@@ -25,11 +27,13 @@
 #' )
 tar_resources_aws <- function(
   bucket,
-  prefix = targets::path_objects_dir_cloud()
+  prefix = targets::path_objects_dir_cloud(),
+  region = character(0)
 ) {
   out <- resources_aws_init(
     bucket = bucket,
-    prefix = prefix
+    prefix = prefix,
+    region = region
   )
   resources_validate(out)
   out

--- a/man/tar_resources_aws.Rd
+++ b/man/tar_resources_aws.Rd
@@ -4,7 +4,11 @@
 \alias{tar_resources_aws}
 \title{Target resources: AWS storage formats}
 \usage{
-tar_resources_aws(bucket, prefix = targets::path_objects_dir_cloud())
+tar_resources_aws(
+  bucket,
+  prefix = targets::path_objects_dir_cloud(),
+  region = character(0)
+)
 }
 \arguments{
 \item{bucket}{Character of length 1, name of an existing
@@ -13,6 +17,9 @@ of the affected targets during the pipeline.}
 
 \item{prefix}{Character of length 1, "directory path"
 in the S3 bucket where the target return values are stored.}
+
+\item{region}{Character of length 1, AWS region containing the S3 bucket.
+Set to \code{NULL} to use the default region.}
 }
 \value{
 Object of class \code{"tar_resources_aws"}, to be supplied

--- a/man/tar_resources_aws.Rd
+++ b/man/tar_resources_aws.Rd
@@ -7,7 +7,7 @@
 tar_resources_aws(
   bucket,
   prefix = targets::path_objects_dir_cloud(),
-  region = character(0)
+  region = NULL
 )
 }
 \arguments{

--- a/tests/aws/test-aws-interactive.R
+++ b/tests/aws/test-aws-interactive.R
@@ -1,0 +1,33 @@
+# Run these tests interactively line by line.
+# There are things to be done in the AWS web console
+# in the middle of the tests. Follow the directions
+# in the comments.
+# As with other AWS tests, use sparingly.
+# We do not want to max out any AWS quotas.
+# And afterwards, manually verify that all the buckets are gone.
+tar_test("aws_qs nonexistent bucket", {
+  skip_if_no_aws()
+  skip_if_not_installed("qs")
+  bucket_name <- random_bucket_name()
+  aws.s3::put_bucket(bucket = bucket_name)
+  expr <- quote({
+    tar_option_set(
+      resources = tar_resources(
+        aws = tar_resources_aws(bucket = !!bucket_name, region = "")
+      )
+    )
+    list(
+      tar_target(x, "x_value", format = "aws_qs"),
+      tar_target(y, c(x, "y_value"), format = "aws_qs")
+    )
+  })
+  expr <- tar_tidy_eval(expr, environment(), TRUE)
+  eval(as.call(list(`tar_script`, expr, ask = FALSE)))
+  tar_make(callr_function = NULL)
+  expect_equal(tar_read(x), "x_value")
+  # Now delete the bucket in the AWS console and make sure it's gone.
+  expect_error(tar_make(callr_function = NULL), class = "tar_condition_run")
+  out <- tar_meta(x, error)$error
+  expect_true(nzchar(out))
+  expect_false(anyNA(out))
+})

--- a/tests/aws/test-class_aws_qs.R
+++ b/tests/aws/test-class_aws_qs.R
@@ -318,3 +318,60 @@ tar_test("aws_qs format works with storage = \"none\"", {
   )
   expect_equal(qs::qread(tmp), "x_value")
 })
+
+tar_test("aws_qs format with custom region", {
+  skip_if_no_aws()
+  skip_if_not_installed("qs")
+  on.exit({
+    aws.s3::delete_object(object = "_targets/objects/x", bucket = bucket_name)
+    aws.s3::delete_object(object = "_targets/objects/y", bucket = bucket_name)
+    aws.s3::delete_object(object = "_targets/objects", bucket = bucket_name)
+    aws.s3::delete_object(object = "_targets", bucket = bucket_name)
+    aws.s3::delete_bucket(bucket = bucket_name)
+  })
+  bucket_name <- random_bucket_name()
+  aws.s3::put_bucket(bucket = bucket_name, region = "us-west-2")
+  expr <- quote({
+    tar_option_set(
+      resources = tar_resources(
+        aws = tar_resources_aws(bucket = !!bucket_name, region = "us-west-2")
+      )
+    )
+    list(
+      tar_target(x, "x_value", format = "aws_qs"),
+      tar_target(y, c(x, "y_value"), format = "aws_qs")
+    )
+  })
+  expr <- tar_tidy_eval(expr, environment(), TRUE)
+  eval(as.call(list(`tar_script`, expr, ask = FALSE)))
+  tar_make(callr_function = NULL)
+  expect_true(
+    aws.s3::object_exists(
+      bucket = bucket_name,
+      object = "_targets/objects/x",
+      region = "us-west-2"
+    )
+  )
+  expect_true(
+    aws.s3::object_exists(
+      bucket = bucket_name,
+      object = "_targets/objects/y",
+      region = "us-west-2"
+    )
+  )
+  expect_false(file.exists(file.path("_targets", "objects", "x")))
+  expect_false(file.exists(file.path("_targets", "objects", "y")))
+  expect_equal(tar_read(x), "x_value")
+  expect_equal(tar_read(y), c("x_value", "y_value"))
+  out <- tar_meta(x)$path[[1]][1]
+  exp <- paste0("bucket=", bucket_name, ":region=us-west-2")
+  expect_equal(out, exp)
+  tmp <- tempfile()
+  aws.s3::save_object(
+    object = "_targets/objects/x",
+    bucket = bucket_name,
+    file = tmp,
+    region = "us-west-2"
+  )
+  expect_equal(qs::qread(tmp), "x_value")
+})

--- a/tests/testthat/test-class_aws.R
+++ b/tests/testthat/test-class_aws.R
@@ -13,3 +13,9 @@ tar_test("metabucket without region", {
   expect_equal(store_aws_bucket(path), "abc")
   expect_null(store_aws_region(path))
 })
+
+tar_test("metabucket compat with targets <= 0.8.1", {
+  path <- c("bucket_name", "object_name")
+  expect_equal(store_aws_bucket(path), "bucket_name")
+  expect_null(store_aws_region(path))
+})

--- a/tests/testthat/test-class_aws.R
+++ b/tests/testthat/test-class_aws.R
@@ -1,0 +1,15 @@
+tar_test("metabucket with region", {
+  metabucket <- store_produce_aws_metabucket(bucket = "abc", region = "xyz")
+  expect_equal(metabucket, "bucket=abc:region=xyz")
+  path <- c(metabucket, "object_name")
+  expect_equal(store_aws_bucket(path), "abc")
+  expect_equal(store_aws_region(path), "xyz")
+})
+
+tar_test("metabucket without region", {
+  metabucket <- store_produce_aws_metabucket(bucket = "abc", region = NULL)
+  expect_equal(metabucket, "bucket=abc:region=")
+  path <- c(metabucket, "object_name")
+  expect_equal(store_aws_bucket(path), "abc")
+  expect_null(store_aws_region(path))
+})

--- a/tests/testthat/test-class_aws_rds.R
+++ b/tests/testthat/test-class_aws_rds.R
@@ -24,7 +24,7 @@ tar_test("store_produce_path()", {
   store <- tar_target(x, "x_value", format = "aws_rds")$store
   store$resources <- list(bucket = "x_bucket")
   out <- store_produce_path(store, "x_name", "x_object")
-  expect_equal(out, c("x_bucket", "_targets/objects/x_name"))
+  expect_equal(out, c("bucket=x_bucket:region=", "_targets/objects/x_name"))
 })
 
 tar_test("validate aws_rds", {

--- a/tests/testthat/test-tar_resources_aws.R
+++ b/tests/testthat/test-tar_resources_aws.R
@@ -1,4 +1,12 @@
 tar_test("tar_resources_aws()", {
-  out <- tar_resources_aws(bucket = "123")
+  out <- tar_resources_aws(bucket = "bucket123")
+  expect_equal(out$bucket, "bucket123")
+  expect_null(out$region)
+  expect_silent(resources_validate(out))
+})
+
+tar_test("tar_resources_aws() with region", {
+  out <- tar_resources_aws(bucket = "bucket123", region = "us-east-1")
+  expect_equal(out$region, "us-east-1")
   expect_silent(resources_validate(out))
 })


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #681

# Summary

This PR adds a `region` argument to `tar_resources_aws()` to allow the user to explicitly declare a region for each AWS S3 buckets (@caewok, #681). Different buckets can now have different regions. This feature required modifying the metadata path for AWS storage formats. Before, the first element of the path was simply the bucket name. Now, it is internally formatted like `"bucket=BUCKET:region=REGION"`, where `BUCKET` is the user-supplied bucket name and `REGION` is the user-supplied region name. The new `targets` is back-compatible with the old metadata format, but if you run the pipeline with `targets` >= 0.8.1.9000 and then downgrade to `targets` <= 0.8.1, any AWS targets will break.

