### PR TITLE
Strip comments in citation output

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -110,6 +110,6 @@ Please note that this package is released with a [Contributor Code of Conduct](h
 
 ## Citation
 
-```{r}
+```{r, comment=NA}
 citation("targets")
 ```


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #

# Summary

Provides a plain text output of the citation which can be more easily copied than a commented one.

```
To cite targets in publications use:

  Landau, W. M., (2021). The targets R package: a dynamic Make-like
  function-oriented pipeline toolkit for reproducibility and
  high-performance computing. Journal of Open Source Software, 6(57),
  2959, https://doi.org/10.21105/joss.02959

A BibTeX entry for LaTeX users is

  @Article{,
    title = {The targets R package: a dynamic Make-like function-oriented pipeline toolkit for reproducibility and high-performance computing},
    author = {William Michael Landau},
    journal = {Journal of Open Source Software},
    year = {2021},
    volume = {6},
    number = {57},
    pages = {2959},
    url = {https://doi.org/10.21105/joss.02959},
  }
```

