### PR TITLE
link to `tar_target()` help page

### DIFF
--- a/R/tar_target.R
+++ b/R/tar_target.R
@@ -159,7 +159,7 @@
 #'   With the exception of `format = "file"`, each target
 #'   gets a file in `_targets/objects`, and each format is a different
 #'   way to save and load this file. See the "Storage formats" section
-#'   for a detailed list of possible data storage formats.
+#'   in [tar_target()] for a detailed list of possible data storage formats.
 #' @param error Character of length 1, what to do if the target
 #'   stops and throws an error. Options:
 #'   * `"stop"`: the whole pipeline stops and throws an error.

--- a/man/tar_option_set.Rd
+++ b/man/tar_option_set.Rd
@@ -93,7 +93,7 @@ of \code{tar_option_set()}.}
 With the exception of \code{format = "file"}, each target
 gets a file in \verb{_targets/objects}, and each format is a different
 way to save and load this file. See the "Storage formats" section
-for a detailed list of possible data storage formats.}
+in \code{\link[=tar_target]{tar_target()}} for a detailed list of possible data storage formats.}
 
 \item{repository}{Character of length 1, remote repository for target
 storage. Choices:

--- a/man/tar_target.Rd
+++ b/man/tar_target.Rd
@@ -67,7 +67,7 @@ when loading \code{packages}.}
 With the exception of \code{format = "file"}, each target
 gets a file in \verb{_targets/objects}, and each format is a different
 way to save and load this file. See the "Storage formats" section
-for a detailed list of possible data storage formats.}
+in \code{\link[=tar_target]{tar_target()}} for a detailed list of possible data storage formats.}
 
 \item{repository}{Character of length 1, remote repository for target
 storage. Choices:

--- a/man/tar_target_raw.Rd
+++ b/man/tar_target_raw.Rd
@@ -76,7 +76,7 @@ If \code{NULL}, the strings is just deparsed from \code{command} (default).}
 With the exception of \code{format = "file"}, each target
 gets a file in \verb{_targets/objects}, and each format is a different
 way to save and load this file. See the "Storage formats" section
-for a detailed list of possible data storage formats.}
+in \code{\link[=tar_target]{tar_target()}} for a detailed list of possible data storage formats.}
 
 \item{repository}{Character of length 1, remote repository for target
 storage. Choices:


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #837 

# Summary

Reading argument `format` in `?tar_option_set` refers to the "Storage formats" section. However, this section is not within `?tar_option_set` but in `?tar_target`. 
Maybe there's even a way to directly link to the section rather than to the start of the help page?

(I am aware that this creates redundancy in `?tar_target` but the positive effect should weigh more?)
