### PR TITLE
Implement token authentication in `gcp_gcs_auth()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,6 +82,7 @@ Suggests:
   future (>= 1.19.1),
   future.batchtools (>= 0.9.0),
   future.callr (>= 0.6.0),
+  gargle (>= 1.2.0),
   googleCloudStorageR (>= 0.7.0),
   gt (>= 0.2.2),
   keras (>= 2.2.5.0),

--- a/R/utils_gcp.R
+++ b/R/utils_gcp.R
@@ -136,7 +136,12 @@ gcp_gcs_upload <- function(
 
 gcp_gcs_auth <- function(verbose = FALSE) {
   if_any(verbose, identity, suppressMessages) (
-    googleCloudStorageR::gcs_auth(Sys.getenv("GCS_AUTH_FILE"))
+    googleCloudStorageR::gcs_auth(
+      token = gargle::token_fetch(
+        scopes = c("https://www.googleapis.com/auth/cloud-platform"),
+        path = Sys.getenv("GCS_AUTH_FILE")
+      )
+    )
   )
 }
 # nocov end


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #866 

# Summary

In this pull request, I have implemented token authentication in `gcp_gcs_auth()` using `gargle::token_fetch()` to allow both service account and user account authentication methods.

I'll then update the manual to describe the GCP auth methods.