### PR TITLE
Fix for dev tidyselect

### DIFF
--- a/tests/testthat/test-tar_newer.R
+++ b/tests/testthat/test-tar_newer.R
@@ -5,5 +5,5 @@ tar_test("tar_newer() works", {
   late <- Sys.time() + as.difftime(1, units = "weeks")
   expect_equal(tar_newer(late), character(0))
   expect_equal(tar_newer(early), "x")
-  expect_equal(tar_newer(early, names = all_of("y")), character(0))
+  expect_equal(tar_newer(early, names = any_of("y")), character(0))
 })

--- a/tests/testthat/test-tar_older.R
+++ b/tests/testthat/test-tar_older.R
@@ -5,5 +5,5 @@ tar_test("tar_older() works", {
   late <- Sys.time() + as.difftime(1, units = "weeks")
   expect_equal(tar_older(early), character(0))
   expect_equal(tar_older(late), "x")
-  expect_equal(tar_older(late, names = all_of("y")), character(0))
+  expect_equal(tar_older(late, names = any_of("y")), character(0))
 })


### PR DESCRIPTION
Since all_of() now always checks the variables even when `strict = FALSE`.
