### PR TITLE
Replace deprecated multiprocess

### DIFF
--- a/R/tar_make_future.R
+++ b/R/tar_make_future.R
@@ -20,7 +20,7 @@
 #' if (identical(Sys.getenv("TAR_EXAMPLES"), "true")) {
 #' tar_dir({ # tar_dir() runs code from a temporary directory.
 #' tar_script({
-#'   future::plan(future::multiprocess, workers = 2)
+#'   future::plan(future::multisession, workers = 2)
 #'   list(
 #'     tar_target(x, 1 + 1),
 #'     tar_target(y, 1 + 1)


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.


# Summary

Minor edit in `tar_make_future`, replacing "multiprocess" which has been deprecated by future with "multisession". 
Deprecation details here: https://github.com/HenrikBengtsson/future/blob/develop/NEWS.md#significant-changes-5

I noticed in the [targets book, hpc chapter](https://books.ropensci.org/targets/hpc.html#future-locally) there is a recommendation to use "callr" from `future.callr`. I left the example for `tar_make_future`  depending on `future` only, wasn't sure if you'd rather the simpler example or recommendation matching the hpc chapter. 

Thank you!