### PR TITLE
Implement `error = "trim"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Replace `pingr` dependency with `base::socketConnection()` for local URL utilities (#1317, #1318, @Adafede).
 * Implement `tar_repository_cas()`, `tar_repository_cas_local()`, and `tar_repository_cas_local_gc()` for content-addressable storage (#1232, #1314, @noamross).
 * Add `tar_format_get()` to make implementing CAS systems easier.
+* Implement `error = "trim"` in `tar_target()` and `tar_option_set()` (#1311, @hadley).
 
 # targets 1.7.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 * Replace `pingr` dependency with `base::socketConnection()` for local URL utilities (#1317, #1318, @Adafede).
 * Implement `tar_repository_cas()`, `tar_repository_cas_local()`, and `tar_repository_cas_local_gc()` for content-addressable storage (#1232, #1314, @noamross).
 * Add `tar_format_get()` to make implementing CAS systems easier.
-* Implement `error = "trim"` in `tar_target()` and `tar_option_set()` (#1311, @hadley).
+* Implement `error = "trim"` in `tar_target()` and `tar_option_set()` (#1310, #1311, @hadley).
 
 # targets 1.7.1
 

--- a/R/class_active.R
+++ b/R/class_active.R
@@ -189,7 +189,9 @@ active_class <- R6::R6Class(
       target <- pipeline_get_target(self$pipeline, name)
       target_debug(target)
       target_update_depend(target, self$pipeline, self$meta)
-      if (target_should_run(target, self$meta)) {
+      if (counter_exists_name(self$scheduler$trimmed, name)) {
+        self$scheduler$trim(target, self$pipeline)
+      } else if (target_should_run(target, self$meta)) {
         self$flush_upload_meta_file(target)
         self$run_target(name)
       } else {

--- a/R/class_builder.R
+++ b/R/class_builder.R
@@ -339,6 +339,7 @@ builder_handle_error <- function(target, pipeline, scheduler, meta) {
     target$settings$error,
     continue = builder_error_continue(target, scheduler),
     abridge = scheduler$abridge(target),
+    trim = scheduler$trim(target),
     stop = builder_error_exit(target, pipeline, scheduler, meta),
     null = builder_error_null(target, pipeline, scheduler, meta),
     workspace = builder_error_exit(target, pipeline, scheduler, meta)

--- a/R/class_builder.R
+++ b/R/class_builder.R
@@ -339,7 +339,7 @@ builder_handle_error <- function(target, pipeline, scheduler, meta) {
     target$settings$error,
     continue = builder_error_continue(target, scheduler),
     abridge = scheduler$abridge(target),
-    trim = scheduler$trim(target),
+    trim = scheduler$trim(target, pipeline),
     stop = builder_error_exit(target, pipeline, scheduler, meta),
     null = builder_error_null(target, pipeline, scheduler, meta),
     workspace = builder_error_exit(target, pipeline, scheduler, meta)

--- a/R/class_options.R
+++ b/R/class_options.R
@@ -516,7 +516,7 @@ options_class <- R6::R6Class(
       deprecate_error_workspace(error)
       tar_assert_flag(
         error,
-        c("stop", "continue", "abridge", "workspace", "null")
+        c("stop", "continue", "null", "abridge", "trim", "workspace")
       )
     },
     validate_memory = function(memory) {

--- a/R/class_pattern.R
+++ b/R/class_pattern.R
@@ -17,7 +17,7 @@ pattern_new <- function(
 
 #' @export
 target_get_children.tar_pattern <- function(target) {
-  target$junction$splits
+  as.character(target$junction$splits)
 }
 
 #' @export

--- a/R/class_scheduler.R
+++ b/R/class_scheduler.R
@@ -22,12 +22,14 @@ scheduler_init <- function(
   )
   reporter <- reporter_init(reporter, seconds_interval = seconds_reporter)
   backoff <- tar_options$get_backoff()
+  canceled <- counter_init()
   scheduler_new(
     graph = graph,
     queue = queue,
     progress = progress,
     reporter = reporter,
-    backoff = backoff
+    backoff = backoff,
+    canceled <- canceled
   )
 }
 
@@ -52,9 +54,10 @@ scheduler_new <- function(
   queue = NULL,
   progress = NULL,
   reporter = NULL,
-  backoff = NULL
+  backoff = NULL,
+  canceled = NULL
 ) {
-  scheduler_class$new(graph, queue, progress, reporter, backoff)
+  scheduler_class$new(graph, queue, progress, reporter, backoff, canceled)
 }
 
 scheduler_class <- R6::R6Class(
@@ -68,18 +71,21 @@ scheduler_class <- R6::R6Class(
     progress = NULL,
     reporter = NULL,
     backoff = NULL,
+    canceled = NULL,
     initialize = function(
       graph = NULL,
       queue = NULL,
       progress = NULL,
       reporter = NULL,
-      backoff = NULL
+      backoff = NULL,
+      canceled = NULL
     ) {
       self$graph <- graph
       self$queue <- queue
       self$progress <- progress
       self$reporter <- reporter
       self$backoff <- backoff
+      self$canceled <- canceled
     },
     count_unfinished_deps = function(name) {
       deps <- self$graph$produce_upstream(name)
@@ -98,12 +104,18 @@ scheduler_class <- R6::R6Class(
       self$progress$abridge()
       self$queue$abridge()
     },
+    trim = function(target) {
+      
+      browser()
+      
+    },
     validate = function() {
       self$graph$validate()
       self$queue$validate()
       self$progress$validate()
       self$reporter$validate()
       self$backoff$validate()
+      counter_validate(self$canceled)
     }
   )
 )

--- a/R/class_scheduler.R
+++ b/R/class_scheduler.R
@@ -22,14 +22,14 @@ scheduler_init <- function(
   )
   reporter <- reporter_init(reporter, seconds_interval = seconds_reporter)
   backoff <- tar_options$get_backoff()
-  canceled <- counter_init()
+  trimmed <- counter_init()
   scheduler_new(
     graph = graph,
     queue = queue,
     progress = progress,
     reporter = reporter,
     backoff = backoff,
-    canceled <- canceled
+    trimmed <- trimmed
   )
 }
 
@@ -55,9 +55,9 @@ scheduler_new <- function(
   progress = NULL,
   reporter = NULL,
   backoff = NULL,
-  canceled = NULL
+  trimmed = NULL
 ) {
-  scheduler_class$new(graph, queue, progress, reporter, backoff, canceled)
+  scheduler_class$new(graph, queue, progress, reporter, backoff, trimmed)
 }
 
 scheduler_class <- R6::R6Class(
@@ -71,21 +71,21 @@ scheduler_class <- R6::R6Class(
     progress = NULL,
     reporter = NULL,
     backoff = NULL,
-    canceled = NULL,
+    trimmed = NULL,
     initialize = function(
       graph = NULL,
       queue = NULL,
       progress = NULL,
       reporter = NULL,
       backoff = NULL,
-      canceled = NULL
+      trimmed = NULL
     ) {
       self$graph <- graph
       self$queue <- queue
       self$progress <- progress
       self$reporter <- reporter
       self$backoff <- backoff
-      self$canceled <- canceled
+      self$trimmed <- trimmed
     },
     count_unfinished_deps = function(name) {
       deps <- self$graph$produce_upstream(name)
@@ -104,10 +104,12 @@ scheduler_class <- R6::R6Class(
       self$progress$abridge()
       self$queue$abridge()
     },
-    trim = function(target) {
-      
-      browser()
-      
+    trim = function(target, pipeline) {
+      parent_name <- target_get_parent(target)
+      parent_target <- pipeline_get_target(pipeline, parent_name)
+      downstream <- self$graph$produce_downstream(parent_name)
+      siblings <- target_get_children(parent_target)
+      counter_set_names(self$trimmed, c(downstream, siblings))
     },
     validate = function() {
       self$graph$validate()
@@ -115,7 +117,7 @@ scheduler_class <- R6::R6Class(
       self$progress$validate()
       self$reporter$validate()
       self$backoff$validate()
-      counter_validate(self$canceled)
+      counter_validate(self$trimmed)
     }
   )
 )

--- a/R/class_stem.R
+++ b/R/class_stem.R
@@ -72,7 +72,13 @@ target_produce_record.tar_stem <- function(target, pipeline, meta) {
 }
 
 #' @export
-target_skip.tar_stem <- function(target, pipeline, scheduler, meta, active) {
+target_skip.tar_stem <- function(
+  target,
+  pipeline,
+  scheduler,
+  meta,
+  active
+) {
   NextMethod()
   stem_restore_buds(target, pipeline, scheduler, meta)
 }

--- a/R/class_target.R
+++ b/R/class_target.R
@@ -207,7 +207,13 @@ target_produce_record <- function(target, pipeline, meta) {
   UseMethod("target_produce_record")
 }
 
-target_skip <- function(target, pipeline, scheduler, meta, active) {
+target_skip <- function(
+  target,
+  pipeline,
+  scheduler,
+  meta,
+  active
+) {
   UseMethod("target_skip")
 }
 

--- a/R/tar_target.R
+++ b/R/tar_target.R
@@ -216,10 +216,17 @@
 #'     up to date for the next run of the pipeline.
 #'   * `"abridge"`: any currently running targets keep running,
 #'     but no new targets launch after that.
-#'   * `"trim"`: any currently running targets keep running,
-#'     and everything downstream of the error is canceled.
-#'     In addition, if the error happens in a dynamic branch,
-#'     then all not-yet-dispatched sibling branches are canceled.
+#'   * `"trim"`: all currently running targets stay running. In addition,
+#'     a target not yet running is allowed to start if:
+#'
+#'       1. It is not downstream of the error, and
+#'       2. It is not a sibling branch from the same [tar_target()] call
+#'         (if the error happened in a dynamic branch).
+#'
+#'     The idea is to avoid starting any new work that the immediate error
+#'     impacts. `error = "trim"` is just like `error = "abridge"`,
+#'     but it allows potentially healthy regions of the dependency graph
+#'     to begin running.
 #'   (Visit <https://books.ropensci.org/targets/debugging.html>
 #'   to learn how to debug targets using saved workspaces.)
 #' @param memory Character of length 1, memory strategy.

--- a/R/tar_target.R
+++ b/R/tar_target.R
@@ -211,13 +211,17 @@
 #'   stops and throws an error. Options:
 #'   * `"stop"`: the whole pipeline stops and throws an error.
 #'   * `"continue"`: the whole pipeline keeps going.
-#'   * `"abridge"`: any currently running targets keep running,
-#'     but no new targets launch after that.
-#'   (Visit <https://books.ropensci.org/targets/debugging.html>
-#'   to learn how to debug targets using saved workspaces.)
 #'   * `"null"`: The errored target continues and returns `NULL`.
 #'     The data hash is deliberately wrong so the target is not
 #'     up to date for the next run of the pipeline.
+#'   * `"abridge"`: any currently running targets keep running,
+#'     but no new targets launch after that.
+#'   * `"trim"`: any currently running targets keep running,
+#'     and everything downstream of the error is canceled.
+#'     In addition, if the error happens in a dynamic branch,
+#'     then all not-yet-dispatched sibling branches are canceled.
+#'   (Visit <https://books.ropensci.org/targets/debugging.html>
+#'   to learn how to debug targets using saved workspaces.)
 #' @param memory Character of length 1, memory strategy.
 #'   If `"persistent"`, the target stays in memory
 #'   until the end of the pipeline (unless `storage` is `"worker"`,

--- a/R/tar_target.R
+++ b/R/tar_target.R
@@ -216,8 +216,8 @@
 #'     up to date for the next run of the pipeline.
 #'   * `"abridge"`: any currently running targets keep running,
 #'     but no new targets launch after that.
-#'   * `"trim"`: all currently running targets stay running. In addition,
-#'     a target not yet running is allowed to start if:
+#'   * `"trim"`: all currently running targets stay running. A queued
+#'     target is allowed to start if:
 #'
 #'       1. It is not downstream of the error, and
 #'       2. It is not a sibling branch from the same [tar_target()] call

--- a/R/tar_target_raw.R
+++ b/R/tar_target_raw.R
@@ -120,7 +120,7 @@ tar_target_raw <- function(
   tar_assert_flag(iteration, c("vector", "list", "group"))
   tar_assert_flag(
     error,
-    c("stop", "continue", "abridge", "workspace", "null")
+    c("stop", "continue", "null", "abridge", "trim", "workspace")
   )
   deprecate_error_workspace(error)
   tar_assert_flag(memory, c("persistent", "transient"))

--- a/man/tar_option_set.Rd
+++ b/man/tar_option_set.Rd
@@ -174,13 +174,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. In addition,
+a target not yet running is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[=tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.

--- a/man/tar_option_set.Rd
+++ b/man/tar_option_set.Rd
@@ -179,8 +179,8 @@ The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
-\item \code{"trim"}: all currently running targets stay running. In addition,
-a target not yet running is allowed to start if:
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
 \enumerate{
 \item It is not downstream of the error, and
 \item It is not a sibling branch from the same \code{\link[=tar_target]{tar_target()}} call

--- a/man/tar_target.Rd
+++ b/man/tar_target.Rd
@@ -124,8 +124,8 @@ The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
-\item \code{"trim"}: all currently running targets stay running. In addition,
-a target not yet running is allowed to start if:
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
 \enumerate{
 \item It is not downstream of the error, and
 \item It is not a sibling branch from the same \code{\link[=tar_target]{tar_target()}} call

--- a/man/tar_target.Rd
+++ b/man/tar_target.Rd
@@ -119,13 +119,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. In addition,
+a target not yet running is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[=tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.

--- a/man/tar_target_raw.Rd
+++ b/man/tar_target_raw.Rd
@@ -134,13 +134,25 @@ stops and throws an error. Options:
 \itemize{
 \item \code{"stop"}: the whole pipeline stops and throws an error.
 \item \code{"continue"}: the whole pipeline keeps going.
-\item \code{"abridge"}: any currently running targets keep running,
-but no new targets launch after that.
-(Visit \url{https://books.ropensci.org/targets/debugging.html}
-to learn how to debug targets using saved workspaces.)
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
+\item \code{"abridge"}: any currently running targets keep running,
+but no new targets launch after that.
+\item \code{"trim"}: all currently running targets stay running. In addition,
+a target not yet running is allowed to start if:
+\enumerate{
+\item It is not downstream of the error, and
+\item It is not a sibling branch from the same \code{\link[=tar_target]{tar_target()}} call
+(if the error happened in a dynamic branch).
+}
+
+The idea is to avoid starting any new work that the immediate error
+impacts. \code{error = "trim"} is just like \code{error = "abridge"},
+but it allows potentially healthy regions of the dependency graph
+to begin running.
+(Visit \url{https://books.ropensci.org/targets/debugging.html}
+to learn how to debug targets using saved workspaces.)
 }}
 
 \item{memory}{Character of length 1, memory strategy.

--- a/man/tar_target_raw.Rd
+++ b/man/tar_target_raw.Rd
@@ -139,8 +139,8 @@ The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.
-\item \code{"trim"}: all currently running targets stay running. In addition,
-a target not yet running is allowed to start if:
+\item \code{"trim"}: all currently running targets stay running. A queued
+target is allowed to start if:
 \enumerate{
 \item It is not downstream of the error, and
 \item It is not a sibling branch from the same \code{\link[=tar_target]{tar_target()}} call

--- a/tests/testthat/test-class_builder.R
+++ b/tests/testthat/test-class_builder.R
@@ -649,45 +649,24 @@ tar_test("error = \"trim\" on a stem", {
     )
   })
   tar_make(callr_function = NULL)
+  names <- c(
+    "a", "c", "c2",
+    "d", tar_meta(d)$children[[1L]], "d2",
+    tar_meta(d2)$children[[1L]], "index"
+  )
   progress <- tar_progress()
-  progress <- progress[order(progress$name), ]
-  expect_equal(
-    progress$name,
-    c(
-      "a", "c", "c2",
-      "d", "d_6d03443cebc2cf01", "d_ef1ae9b9954fc770", "d2",
-      "d2_6c00f247f5280799",
-      "d2_b37ef839cbb72a79", "index"
-    )
-  )
-  expect_equal(
-    progress$progress,
-    c(
-      "errored",
-      "completed", "completed", "completed", "completed", "completed",
-      "completed", "completed", "completed", "completed"
-    )
-  )
+  expect_equal(nrow(progress), 10L)
+  expect_false(any(c("b", "b2") %in% progress$name))
+  progress <- tar_progress(names = tidyselect::any_of(names))
+  expect_equal(progress$name, names)
+  expect_equal(progress$progress, c("errored", rep("completed", 9L)))
   tar_make(callr_function = NULL)
   progress <- tar_progress()
-  progress <- progress[order(progress$name), ]
-  expect_equal(
-    progress$name,
-    c(
-      "a", "c", "c2",
-      "d", "d_6d03443cebc2cf01", "d_ef1ae9b9954fc770", "d2",
-      "d2_6c00f247f5280799",
-      "d2_b37ef839cbb72a79", "index"
-    )
-  )
-  expect_equal(
-    progress$progress,
-    c(
-      "errored",
-      "skipped", "skipped", "skipped", "skipped", "skipped",
-      "skipped", "skipped", "skipped", "skipped"
-    )
-  )
+  expect_equal(nrow(progress), 10L)
+  expect_false(any(c("b", "b2") %in% progress$name))
+  progress <- tar_progress(names = tidyselect::any_of(names))
+  expect_equal(progress$name, names)
+  expect_equal(progress$progress, c("errored", rep("skipped", 9L)))
 })
 
 tar_test("error = \"trim\" on a dynamic branch", {
@@ -706,43 +685,24 @@ tar_test("error = \"trim\" on a dynamic branch", {
     )
   })
   tar_make(callr_function = NULL)
+  names <- c(
+    "c", "c2",
+    "d", tar_meta(d)$children[[1L]], "d2",
+    tar_meta(d2)$children[[1L]], "index"
+  )
   progress <- tar_progress()
-  progress <- progress[order(progress$name), ]
-  expect_equal(
-    progress$name,
-    c(
-      "a", "a_ef1ae9b9954fc770", "c", "c2",
-      "d", "d_6d03443cebc2cf01", "d_ef1ae9b9954fc770", "d2",
-      "d2_6c00f247f5280799",
-      "d2_b37ef839cbb72a79", "index"
-    )
-  )
-  expect_equal(
-    progress$progress,
-    c(
-      "errored", "errored",
-      "completed", "completed", "completed", "completed", "completed",
-      "completed", "completed", "completed", "completed"
-    )
-  )
+  expect_equal(nrow(progress), 11L)
+  expect_false(any(c("b", "b2") %in% progress$name))
+  progress <- tar_progress(names = tidyselect::starts_with("a"))
+  expect_equal(unique(progress$progress), "errored")
+  progress <- tar_progress(names = tidyselect::any_of(names))
+  expect_equal(unique(progress$progress), "completed")
   tar_make(callr_function = NULL)
   progress <- tar_progress()
-  progress <- progress[order(progress$name), ]
-  expect_equal(
-    progress$name,
-    c(
-      "a", "a_ef1ae9b9954fc770", "c", "c2",
-      "d", "d_6d03443cebc2cf01", "d_ef1ae9b9954fc770", "d2",
-      "d2_6c00f247f5280799",
-      "d2_b37ef839cbb72a79", "index"
-    )
-  )
-  expect_equal(
-    progress$progress,
-    c(
-      "errored", "errored",
-      "skipped", "skipped", "skipped", "skipped", "skipped",
-      "skipped", "skipped", "skipped", "skipped"
-    )
-  )
+  expect_equal(nrow(progress), 11L)
+  expect_false(any(c("b", "b2") %in% progress$name))
+  progress <- tar_progress(names = tidyselect::starts_with("a"))
+  expect_equal(unique(progress$progress), "errored")
+  progress <- tar_progress(names = tidyselect::any_of(names))
+  expect_equal(unique(progress$progress), "skipped")
 })


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #1310, #1331

# Summary

`error = "trim"` is a new error option that adds most of the nuance @hadley suggested in #1310. Like the existing `error = "abridge"`, `error = "trim"` allows all currently running targets to keep running. But unlike  `"abridge"`, `"trim"` may allow other targets to start as well. A target can start if it is not a downstream target or a sibling branch of the target that errored. This helps work unaffected by the error keep going.