### PR TITLE
Use parallel tests + avoid partial matching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -113,5 +113,7 @@ Encoding: UTF-8
 Language: en-US
 VignetteBuilder: knitr
 Config/testthat/edition: 3
+Config/testthat/parallel: TRUE
+Config/testthat/start-first: tar_repository_cas_local,tar_outdated,tar_repository_cas,tar_sitrep
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/R/class_database.R
+++ b/R/class_database.R
@@ -110,7 +110,7 @@ database_class <- R6::R6Class(
     set_row = function(row) {
       lookup_set(
         .subset2(self, "lookup"),
-        name = as.character(.subset2(row, "name")),
+        names = as.character(.subset2(row, "name")),
         object = as.list(row)
       )
     },

--- a/R/class_future.R
+++ b/R/class_future.R
@@ -134,7 +134,7 @@ future_class <- R6::R6Class(
       future <- do.call(what = future::future, args = args)
       lookup_set(
         lookup = self$worker_list,
-        name = target_get_name(target),
+        names = target_get_name(target),
         object = future
       )
     },

--- a/tests/testthat/test-class_builder.R
+++ b/tests/testthat/test-class_builder.R
@@ -208,7 +208,6 @@ tar_test("builder writing from worker", {
 
 tar_test("retrieval = \"none\"", {
   skip_cran()
-  skip_cran()
   tar_script({
     list(
       tar_target(x, 1, memory = "transient"),


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted a [discussion topic](https://github.com/ropensci/targets/discussions) or [issue](https://github.com/ropensci/targets/issues) to discuss my idea with the maintainer.

# Summary

Speed up test by using testthat parallel + avoid partial matching (caught by having this set in Rprofile)

```r
  options(
    warnPartialMatchArgs = TRUE,
    warnPartialMatchDollar = TRUE,
    warnPartialMatchAttr = TRUE
  )
```

This contribution is meaningless, but thought I'd send it anyway! By looking at the most time consuming tests, I set them to run first with testthat which reduces test run time !

I am actually trying to find a way to make messages more colorful but didn't succeed (yet)

My goal is to end up with a message that looks like this
![image](https://github.com/user-attachments/assets/8c7e5a58-5f3f-473c-88d3-17629cc64a75)
Currently, it looks like this

![image](https://github.com/user-attachments/assets/21b839a1-bbcc-4597-b25a-85da133dd15e)

