### PR TITLE
fix: Remove correction for off-by-one error in igraph

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Imports:
   cli (>= 2.0.2),
   codetools (>= 0.2.16),
   data.table (>= 1.12.8),
-  igraph (>= 2.0.0),
+  igraph (>= 2.1.2),
   knitr (>= 1.34),
   ps (>= 1.8.0),
   R6 (>= 2.4.1),
@@ -109,6 +109,8 @@ Suggests:
   torch (>= 0.1.0),
   usethis (>= 1.6.3),
   visNetwork (>= 2.1.2)
+Remotes: 
+  igraph/rigraph
 Encoding: UTF-8
 Language: en-US
 VignetteBuilder: knitr

--- a/R/utils_igraph.R
+++ b/R/utils_igraph.R
@@ -27,7 +27,9 @@ targets_adjacent_vertices <- function(graph, v, mode) {
   index <- igraph::adjacent_vertices(graph = graph, v = v, mode = mode)
   index <- unlist(index, use.names = FALSE)
   index <- unique(index)
-  igraph::V(graph)$name[index + 1]
+  # igraph >= 2.1.2 fixes the off-by-one error
+  # https://github.com/igraph/rigraph/pull/1606
+  igraph::V(graph)$name[index]
 }
 
 igraph_leaves <- function(igraph) {


### PR DESCRIPTION
Upstream: https://github.com/igraph/rigraph/pull/1606.

The igraph 2.1.2 release is waiting in CRANs queue. Kindly requesting permission to release with short notice. Can you push a targets update soon, or do we need compatibility code?

Similar problems in drake.