### PR TITLE
Fix typo in tar_repository_cas.R

### DIFF
--- a/R/tar_repository_cas.R
+++ b/R/tar_repository_cas.R
@@ -156,7 +156,7 @@
 #'
 #'   The `list` function increases efficiency by reducing repeated calls
 #'   to the `exists` function (see above) or entirely avoiding them
-#'   if `consistent` is `TRUE.
+#'   if `consistent` is `TRUE`.
 #'
 #'   The `list` function should return a character vector of keys that
 #'   already exist in the CAS system.


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://ropensci.org/code-of-conduct/) and the [contributing guidelines](https://github.com/ropensci/targets/blob/main/CONTRIBUTING.md).

# Summary

Fixed a very small typo in R/tar_repository_cas.R.
